### PR TITLE
Feature/scheduled doc snapshots

### DIFF
--- a/demo/server/main.js
+++ b/demo/server/main.js
@@ -1,6 +1,9 @@
 import { Meteor } from 'meteor/meteor';
-import 'meteor/prosemeteor:prosemirror';
+import { ProseMeteorServer } from 'meteor/prosemeteor:prosemirror';
 
 Meteor.startup(() => {
   // code to run on server at startup
 });
+
+// setup ProseMeteor on server
+let proseMeteorServer = new ProseMeteorServer({ snapshotIntervalMs: 5000 });

--- a/lib/imports/api/authority/server/authority-manager.js
+++ b/lib/imports/api/authority/server/authority-manager.js
@@ -1,5 +1,6 @@
 import { Authority } from './authority';
 import { Meteor } from 'meteor/meteor';
+import { Mongo } from 'meteor/mongo';
 import { check } from 'meteor/check';
 
 export class AuthorityManager {
@@ -14,6 +15,9 @@ export class AuthorityManager {
   * @constructor
   */
   constructor({ documentsColl, streamer, snapshotIntervalMs }) {
+    check(documentsColl, Mongo.Collection);
+    check(streamer, Meteor.Streamer);
+    check(snapshotIntervalMs, Number);
     this.documentsColl = documentsColl;
     this.authorities = {};
     this.streamerServer = streamer;
@@ -62,6 +66,7 @@ export class AuthorityManager {
   * @param {String} params.docId       the unique id of the doc
   */
   openDoc({ docId }) {
+    check(docId, String);
     if (!docId) {
       throw new Meteor.Error('AuthorityManager.openDoc.nonexistant', 'This AuthorityManager doesn\'t have an Authority tracking a document with docId "' + docId + '".');
     }
@@ -85,6 +90,7 @@ export class AuthorityManager {
    * @return {{ version: Number, docJSON: Object}}
    */
   latestDocState({ docId }) {
+    check(docId, String);
     if (!this.authorities[docId]) {
       throw new Meteor.Error('AuthorityManager.latestDocState.nonexistant', 'This AuthorityManager doesn\'t have an Authority tracking a document with docId "' + docId + '".');
     }
@@ -98,6 +104,8 @@ export class AuthorityManager {
   * @param {String} params.docId          id of the doc
   */
   stepsSince({ version, docId }) {
+    check(version, Number);
+    check(docId, String);
     if (!this.authorities[docId]) {
       throw new Meteor.Error('AuthorityManager.stepsSince.nonexistant', 'This AuthorityManager doesn\'t have an Authority tracking a document with docId "' + docId + '".');
     }
@@ -113,6 +121,10 @@ export class AuthorityManager {
   * @param {Array} params.stepsJSON       steps to be received, in JS object/array form (not yet Step instances)
   */
   receiveSteps({ docId, version, stepsJSON, clientId }) {
+    check(docId, String);
+    check(version, Number);
+    check(stepsJSON, Array);
+    check(clientId, Number);
     if (!this.authorities[docId]) {
       throw new Meteor.Error('AuthorityManager.receiveSteps.nonexistant', 'This AuthorityManager doesn\'t have an Authority tracking a document with docId "' + docId + '".');
     }

--- a/lib/imports/api/authority/server/authority-manager.js
+++ b/lib/imports/api/authority/server/authority-manager.js
@@ -56,6 +56,12 @@ export class AuthorityManager {
         check(version, Number);
         check(stepsJSON, Array);
         self.receiveSteps({ docId, clientId, version, stepsJSON });
+      },
+
+      // open a doc, creating an authority for it
+      'ProseMeteor.openDoc'({ docId }) {
+        check(docId, String);
+        self.openDoc({ docId });
       }
     });
   }

--- a/lib/imports/api/authority/server/authority-manager.js
+++ b/lib/imports/api/authority/server/authority-manager.js
@@ -16,6 +16,7 @@ export class AuthorityManager {
     this.documentsCollection = documentCollection;
     this.authorities = {};
     this.streamerServer = streamer;
+    // this.snapshotIntervalSeconds
 
     this.setupClientMethods();
   }

--- a/lib/imports/api/authority/server/authority-manager.js
+++ b/lib/imports/api/authority/server/authority-manager.js
@@ -8,15 +8,16 @@ export class AuthorityManager {
   * and their corresponding Authority.
   *
   * @param {Object} params
-  * @param {Collection} params.collection     a Collection instance that is used to store ProseMirror docs
-  * @param {Streamer}  params.streamer        a Streamer object that contains .emit() and .on() methods for streaming events with clients
+  * @param {Collection} params.collection       a Collection instance that is used to store ProseMirror docs
+  * @param {Streamer}  params.streamer          a Streamer object that contains .emit() and .on() methods for streaming events with clients
+  * @param {Number} params.snapshotIntervalMs   interval in millseconds that Authority will store a snapshot of an open doc to db
   * @constructor
   */
-  constructor({ documentCollection, streamer }) {
-    this.documentsCollection = documentCollection;
+  constructor({ documentsColl, streamer, snapshotIntervalMs }) {
+    this.documentsColl = documentsColl;
     this.authorities = {};
     this.streamerServer = streamer;
-    // this.snapshotIntervalSeconds
+    this.snapshotIntervalMs = snapshotIntervalMs;
 
     this.setupClientMethods();
   }
@@ -72,8 +73,9 @@ export class AuthorityManager {
     // create a new authority
     this.authorities[docId] = new Authority({
       docId,
-      documentsCollection: this.documentsCollection,
-      streamer: this.streamerServer
+      documentsColl: this.documentsColl,
+      streamer: this.streamerServer,
+      snapshotIntervalMs: this.snapshotIntervalMs
     });
     return;
   }
@@ -115,91 +117,7 @@ export class AuthorityManager {
       throw new Meteor.Error('AuthorityManager.receiveSteps.nonexistant', 'This AuthorityManager doesn\'t have an Authority tracking a document with docId "' + docId + '".');
     }
     this.authorities[docId].receiveSteps({ clientId, version, stepsJSON });
+    //     this.authorities[docId].receiveSteps.bind(this.authorities[docId], { clientId, version, stepsJSON });
+
   }
 }
-
-// import { Mongo } from 'meteor/mongo';
-// import { ProseMirror } from './../../../prosemirror/dist/edit';
-// import { Streamer } from 'meteor/rocketchat:streamer';
-// import { Random } from 'meteor/random';
-//
-// //--------------  example use --------------
-// // create a new manager that tracks N number of documents
-// const proseMeteorManager = new ProseMeteorManager(new Mongo.Collection('prosemeteor_snapshots'));
-// // when a user connects to a brand new doc, we call openDoc()
-// const newDocId = proseMeteorManager.openDoc();
-// // lets assume the newDocId is simply the string 'newDocId'. when another user connects we call openDoc() again. since it already exists
-// // and another user is already vieweing it we've already got it in memory, so nothing will happen
-// proseMeteorManager.openDoc('newDocId');
-// // some point later, the last user viewing a doc leaves, so nobody is viewing the doc anymore. we remove it from memory
-// proseMeteorManager.disconnectDoc('someDocId');
-//
-// class ProseMeteorManager {
-//   /**
-//   *  Central manager to track any number of ProseMirror documents. Manages a Authority for each individual document,
-//   *  @constructor
-//   */
-//   constructor(documentsCollection) {
-//     // store the collection that holds doc snapshots
-//     this.documentsCollection = documentsCollection;
-//     // maintain an object containing all authorities, one authority per doc in the format { <docId1>: Authority, <docId2>: Authority }
-//     this.authorities = {};
-//   }
-//   /**
-//   * Open a ProseMirror document. If no docId provided, creates a new doc. Otherwise loads the latest snapshot of the doc with docId if it's not loaded yet. Creates
-//   * a new Authority to track the doc and returns the unique docId.
-//   * @param {String}  [docId]       optional, the unique id of the doc. if none provided, a new doc will be created
-//   * @returns {String} docId
-//   */
-//   openDoc(docId) {
-//     // if no docId provided, create a new document
-//     if (!docId) {
-//       return this.createDoc();
-//     }
-//     // if we're already tracking this doc with an authority, we're all set
-//     if (this.authorities[docId]) {
-//       return docId;
-//     }
-//     // if docId provided, load the existing doc
-//     this.authorities[docId] = new Authority(docId, this.documentsCollection);
-//     // if this existing doc has a snapshot in db, load the latest one
-//     if (this.numberOfSnapshots(docId) > 0) {
-//        this.authorities[docId].loadLatestSnapshot();
-//     }
-//     return docId;
-//   }
-//   /**
-//   * Create a new ProseMirror document with its own Authority, and return a unique docId for the new doc.
-//   * @returns {String}
-//   */
-//   createDoc() {
-//     const docId = Random.id();
-//     this.authorities[docId] = new Authority(docId, this.documentsCollection);
-//     return docId;
-//   }
-//   /**
-//   *  If no more users are editing a doc, it doesn't need to be kept in memory. This will save the doc's latest
-//   * state and remove it from memory.
-//   */
-//   disconnectDoc(docId) {
-//     // store the docs state in a snapshot
-//     this.authorities[docId].storeSnapshot();
-//     // now remove from memory
-//     delete this.authorities[docId];
-//   }
-//   /**
-//    * Return the number of snapshots that are currently stored for this doc.
-//    * @return {Number}
-//    */
-//   static numberOfSnapshots(docId) {
-//     return documentsCollection.find({ docId }).count;
-//   }
-//   /**
-//    * Return the latest stored document snapshot in a JSON string.
-//    * @return {JSON}
-//    */
-//   static getLatestDocSnapshotJSON(docId) {
-//     const snapshot = documentsCollection.findOne({ docId, { sort: { timestamp: 1 }}});
-//     return JSON.stringify(snapshot)
-//   }
-// }

--- a/lib/imports/api/authority/server/authority.js
+++ b/lib/imports/api/authority/server/authority.js
@@ -1,3 +1,4 @@
+import { Meteor } from 'meteor/meteor';
 import { Step } from './../../../prosemirror/dist/transform';
 import { defaultSchema } from './../../../prosemirror/dist/model/defaultschema';
 import { getLatestDocSnapshot } from './../../documents/both/methods';
@@ -8,30 +9,37 @@ export class Authority {
    * Central authority to track a ProseMirror document, apply steps from clients, and notify clients when changes occur.
    * @param {Object} params
    * @param {String} params.docId                     the id of the doc this Authority tracks
-   * @param {Collection} params.documentsCollection   a Meteor Collection that is used to store ProseMirror docs
+   * @param {Collection} params.documentsColl       a Meteor Collection that is used to store ProseMirror docs
    * @param {Streamer}  params.streamer               a Streamer object that contains .emit() and .on() methods for streaming events with clients
+   * @param {Number} params.snapshotIntervalMs       interval in millseconds that Authority will store a snapshot of an open doc to db
    * @constructor
    */
-  constructor({ docId, documentsCollection, streamer }) {
+  constructor({ docId, documentsColl, streamer, snapshotIntervalMs }) {
     console.log('Authority created for doc id: ' + docId);
     this.docId = docId;
+    this.documentsColl = documentsColl;
+    this.streamerServer = streamer;
+    this.snapshotIntervalMs = snapshotIntervalMs;
 
     getLatestDocSnapshot.call({
       docId: this.docId
     }, (err, res) => {
-      let { version, timestamp, docJSON } = res;
       if (err) {
-        console.error('Authority error getting latest snapshot for doc ' + this.docId + ':', err);
+        throw new Meteor.Error(500, 'Authority error getting latest snapshot for doc ' + this.docId + ':' + err);
       }
+      let { version, timestamp, docJSON } = res;
       console.log('Authority got latest snapshot for doc ' + this.docId + ':', JSON.stringify(res, null, 2));
 
       this.doc = defaultSchema.nodeFromJSON(docJSON);
-      this.documentsCollection = documentsCollection;
       this.steps = [];
       this.stepClientIds = [];
-      this.streamerServer = streamer;
-    });
 
+      // store info about last snapshot so we only store on interval, and only when changes have occurred
+      this.latestSnapshot = res;
+
+      // start interval to store doc snapshots
+      this.startSnapshotInteval();
+    });
   }
 
   /**
@@ -71,8 +79,8 @@ export class Authority {
       this.steps.push(step);
       this.stepClientIds.push(clientId);
     });
-    console.log('Authority notifying clients of new steps');
     // notify listening clients that new steps have arrived
+    console.log('Authority notifying clients of new steps');
     this.streamerServer.emit('authorityNewSteps');
   }
 
@@ -88,25 +96,72 @@ export class Authority {
       clientIds: this.stepClientIds.slice(version)
     };
   }
-  // /**
-  //  * Store a snapshot of the current document in the documentsCollection
-  //  */
-  // storeSnapshot() {
-  //   const doc = this.pm.doc;
-  //   const newSnapshotJSON = doc.toJSON();
-  //   const newSnapshotNumber = ProseMeteorManager.numberOfSnapshots() + 1;
-  //   this.documentsCollection.insert({
-  //     docId: this.docId,
-  //     docJSON: newSnapshotJSON,
-  //     timestamp: Date.now(),
-  //     number: newSnapshotNumber
-  //   });
-  // }
+
+  /**
+  * Returns total number of snapshots in db for this Authority's document.
+  * @returns {Number}
+  */
+  numberOfSnapshots(){
+    return this.documentsColl.find({ docId: this.docId }).count();
+  }
+
+  /**
+  * Starts the timer interval to store doc snapshots to db.
+  */
+  startSnapshotInteval() {
+    this.snapshotIntervalTimer = Meteor.setInterval(() => {
+      // only store snapshot if changes have occurred since last snapshot
+      let latestSnapshotVersion = this.latestSnapshot.version;
+      let version = this.version();
+      if (version > latestSnapshotVersion) {
+        console.log('Authority storing snapshot for doc "' + this.docId + '", version ' + version);
+        this.storeSnapshot();
+      }
+    }, this.snapshotIntervalMs);
+  }
+
+  /**
+  * Clears the snapshot interval.
+  */
+  stopSnapshotInterval() {
+    Meteor.clearInterval(this.snapshotIntervalTimer);
+  }
+
+  /**
+  * Returns the version number of this Authority's document.
+  * @returns {Number}
+  */
+  version() {
+    let version;
+    if (this.numberOfSnapshots() === 0) {
+      version = this.steps.length;
+    } else {
+      // if there's a previous snapshot, current doc version is last snapshot's version + the number of steps since then
+      let latestSnapshotVersion = this.latestSnapshot.version;
+      version = latestSnapshotVersion + this.stepsSince({ version: latestSnapshotVersion }).steps.length;
+    }
+    return version;
+  }
+
+  /**
+   * Store a snapshot of the current document in the documentsColl
+   */
+  storeSnapshot() {
+    const newSnapshot = {
+      docId: this.docId,
+      docJSON: this.doc.toJSON(),
+      version: this.version(),
+      timestamp: Date.now()
+    }
+
+    this.documentsColl.insert(newSnapshot);
+    this.latestSnapshot = newSnapshot;
+  }
   // /**
   // * Loads the latest snapshot from db and sets it to this authority's PM instance's doc state.
   // */
   // loadLatestSnapshot() {
-  //   const snapshotJSON = ProseMeteorManager.getLatestDocSnapshotJSON(this.docId);
-  //   this.pm.setDoc(this.pm.schema.nodeFromJSON(lastSnapshot));
+  //   // const snapshotJSON = ProseMeteorManager.getLatestDocSnapshotJSON(this.docId);
+  //   // this.pm.setDoc(this.pm.schema.nodeFromJSON(lastSnapshot));
   // }
 }

--- a/lib/imports/api/authority/server/authority.js
+++ b/lib/imports/api/authority/server/authority.js
@@ -1,8 +1,11 @@
 import { Meteor } from 'meteor/meteor';
+import { Mongo } from 'meteor/mongo';
 import { Step } from './../../../prosemirror/dist/transform';
+import { CollabStep } from './collab-step';
+import { CollabStepClientId } from './collab-step-client-id';
 import { defaultSchema } from './../../../prosemirror/dist/model/defaultschema';
 import { getLatestDocSnapshot } from './../../documents/both/methods';
-
+import { check } from 'meteor/check';
 
 export class Authority {
   /**
@@ -15,11 +18,16 @@ export class Authority {
    * @constructor
    */
   constructor({ docId, documentsColl, streamer, snapshotIntervalMs }) {
+    check(docId, String);
+    check(documentsColl, Mongo.Collection);
+    check(streamer, Meteor.Streamer);
+    check(snapshotIntervalMs, Number);
     console.log('Authority created for doc id: ' + docId);
     this.docId = docId;
     this.documentsColl = documentsColl;
     this.streamerServer = streamer;
     this.snapshotIntervalMs = snapshotIntervalMs;
+    this.numberOfSnapshots = this.documentsColl.find({ docId: this.docId }).count();
 
     getLatestDocSnapshot.call({
       docId: this.docId
@@ -38,7 +46,7 @@ export class Authority {
       this.latestSnapshot = res;
 
       // start interval to store doc snapshots
-      this.startSnapshotInteval();
+      this.startSnapshotInterval();
     });
   }
 
@@ -48,7 +56,7 @@ export class Authority {
    */
   latestDocState() {
     return {
-      version: this.steps.length,
+      version: this.version(),
       docJSON: this.doc.toJSON()
     };
   }
@@ -56,11 +64,15 @@ export class Authority {
   /*
   * Receives steps from a client, applying them to the local doc.
   * @param {Object} params
-  * @param {Number} params.version        doc version the client is submitting for
   * @param {Number} params.clientId       client id used by ProseMirror
   * @param {Array} params.stepsJSON       steps to be received, in JS object/array form (not yet Step instances)
+  * @param {Number} params.version        doc version the client is submitting for
   */
   receiveSteps({ clientId, stepsJSON, version }) {
+    check(clientId, Number);
+    check(stepsJSON, Array);
+    check(version, Number);
+    const currentDocVersion = this.version();
     // parse the steps from json and convert them into Step instances
     const stepObjects = stepsJSON.map((step) => {
       return Step.fromJSON(defaultSchema, step);
@@ -69,15 +81,15 @@ export class Authority {
 
     // if the client submitted steps but that client didn't have the latest version
     // of the doc, stop since they must be applied to newest doc version
-    if (version !== this.steps.length) {
+    if (version !== currentDocVersion) {
       console.log('client ' + clientId + 'didn\'t have the latest version, Authority not accepting changes');
       return;
     }
     // apply and accumulate new steps
     stepObjects.forEach((step) => {
       this.doc = step.apply(this.doc).doc;
-      this.steps.push(step);
-      this.stepClientIds.push(clientId);
+      this.steps.push(new CollabStep({ versionAppliedTo: currentDocVersion, step }));
+      this.stepClientIds.push(new CollabStepClientId({ versionAppliedTo: currentDocVersion, clientId }))
     });
     // notify listening clients that new steps have arrived
     console.log('Authority notifying clients of new steps');
@@ -91,24 +103,30 @@ export class Authority {
    * @return {Object} stepsSince  object with "steps" array and "clientIds" array
    */
   stepsSince({ version }) {
+    check(version, Number);
+    let steps = [];
+    let clientIds = [];
+    // iterate over all steps and find the steps/stepClientIds applied since specified version
+    for (let i = 0; i < this.steps.length; i++) {
+      const thisCollabStep = this.steps[i];
+      const thisCollabClientId = this.stepClientIds[i];
+      if (thisCollabStep.versionAppliedTo >= version) {
+        steps.push(thisCollabStep.step);
+      }
+      if (thisCollabClientId.versionAppliedTo >= version) {
+        clientIds.push(thisCollabClientId.clientId);
+      }
+    }
     return {
-      steps: this.steps.slice(version),
-      clientIds: this.stepClientIds.slice(version)
-    };
-  }
-
-  /**
-  * Returns total number of snapshots in db for this Authority's document.
-  * @returns {Number}
-  */
-  numberOfSnapshots(){
-    return this.documentsColl.find({ docId: this.docId }).count();
+      steps,
+      clientIds
+    }
   }
 
   /**
   * Starts the timer interval to store doc snapshots to db.
   */
-  startSnapshotInteval() {
+  startSnapshotInterval() {
     this.snapshotIntervalTimer = Meteor.setInterval(() => {
       // only store snapshot if changes have occurred since last snapshot
       let latestSnapshotVersion = this.latestSnapshot.version;
@@ -133,7 +151,7 @@ export class Authority {
   */
   version() {
     let version;
-    if (this.numberOfSnapshots() === 0) {
+    if (this.numberOfSnapshots === 0) {
       version = this.steps.length;
     } else {
       // if there's a previous snapshot, current doc version is last snapshot's version + the number of steps since then
@@ -156,6 +174,7 @@ export class Authority {
 
     this.documentsColl.insert(newSnapshot);
     this.latestSnapshot = newSnapshot;
+    this.numberOfSnapshots ++;
   }
   // /**
   // * Loads the latest snapshot from db and sets it to this authority's PM instance's doc state.

--- a/lib/imports/api/authority/server/collab-step-client-id.js
+++ b/lib/imports/api/authority/server/collab-step-client-id.js
@@ -1,0 +1,16 @@
+import { check } from 'meteor/check';
+
+/** Class representing a step's client id associated with a collaborative document, with version data. */
+export class CollabStepClientId {
+  /**
+  * @param {Object} params
+  * @param {Number} params.versionAppliedTo   the version this step was applied to
+  * @param {Number} params.clientId           the ProseMirror Step instance
+  */
+  constructor({ versionAppliedTo, clientId }) {
+    check(versionAppliedTo, Number);
+    check(clientId, Number);
+    this.versionAppliedTo = versionAppliedTo;
+    this.clientId = clientId;
+  }
+}

--- a/lib/imports/api/authority/server/collab-step.js
+++ b/lib/imports/api/authority/server/collab-step.js
@@ -1,0 +1,17 @@
+import { check } from 'meteor/check';
+import { Step } from './../../../prosemirror/dist/transform';
+
+/** Class representing a Step applied to a collaborative document, with version data. */
+export class CollabStep {
+  /**
+  * @param {Object} params
+  * @param {Number} params.versionAppliedTo   the version this step was applied to
+  * @param {Object} params.step           the ProseMirror Step instance
+  */
+  constructor({ versionAppliedTo, step }) {
+    check(versionAppliedTo, Number);
+    check(step, Step);
+    this.versionAppliedTo = versionAppliedTo;
+    this.step = step;
+  }
+}

--- a/lib/imports/api/collab-editor/client/collab-editor.js
+++ b/lib/imports/api/collab-editor/client/collab-editor.js
@@ -57,6 +57,7 @@ export default class CollabEditor {
   * @param {Object} params.docJSON     the doc's state represented as JS object
   */
   createEditor({ version, docJSON }) {
+    console.log('Creating collab editor with doc version: ' + version);
     this.editor = new ProseMirror({
       ...this.proseMirrorOptions,
       collab: {

--- a/lib/imports/api/prosemeteor/server/prosemeteor-server.js
+++ b/lib/imports/api/prosemeteor/server/prosemeteor-server.js
@@ -1,0 +1,34 @@
+import { Meteor } from 'meteor/meteor';
+import { AuthorityManager } from './../../authority/server/authority-manager';
+import { check } from 'meteor/check';
+
+
+export class ProseMeteorServer {
+  constructor({ documentsColl }) {
+    // store documents collection
+    this.documentsColl = documentsColl;
+    // create streamer for event communication with client
+    this.streamerServer = new Meteor.Streamer('prosemirror-pipe', { retransmit : false });
+    this.streamerServer.allowRead('all');
+    this.streamerServer.allowWrite('all');
+
+    // create authority manager  to create, delete authorities and communicate with clients
+    this.authorityManager = new AuthorityManager({
+      documentsCollection: this.documentsColl,
+      streamer: this.streamerServer
+    });
+
+    // set up Meteor methods
+    this.setupClientMethods();
+  }
+
+  setupClientMethods() {
+    let self = this;
+    Meteor.methods({
+      'ProseMeteor.openDoc'({ docId }) {
+        check(docId, String);
+        self.authorityManager.openDoc({ docId });
+      }
+    });
+  }
+}

--- a/lib/imports/api/prosemeteor/server/prosemeteor-server.js
+++ b/lib/imports/api/prosemeteor/server/prosemeteor-server.js
@@ -1,10 +1,21 @@
 import { Meteor } from 'meteor/meteor';
 import { AuthorityManager } from './../../authority/server/authority-manager';
 import { check } from 'meteor/check';
+import { documentsColl } from './../../documents/both/collection';
 
 
+/**
+* Main ProseMeteor server class that instantiates all of ProseMeteor on the server.
+*/
 export class ProseMeteorServer {
-  constructor({ documentsColl }) {
+  /*
+  * Main ProseMeteor class on the server.
+  * @param {Object} params
+  * @param {Collection} params.documentsColl     Collection PM docs are stored in
+  * @param {Number} [params.snapshotIntervalMs]  interval in milliseconds that documents are backed up to a snapshot in db
+  * @constructor
+  */
+  constructor({ snapshotIntervalMs = 5000 }) {
     // store documents collection
     this.documentsColl = documentsColl;
     // create streamer for event communication with client
@@ -14,14 +25,18 @@ export class ProseMeteorServer {
 
     // create authority manager  to create, delete authorities and communicate with clients
     this.authorityManager = new AuthorityManager({
-      documentsCollection: this.documentsColl,
-      streamer: this.streamerServer
+      documentsColl,
+      streamer: this.streamerServer,
+      snapshotIntervalMs
     });
 
     // set up Meteor methods
     this.setupClientMethods();
   }
 
+  /*
+  * Set up Meteor methods for communication with clients.
+  */
   setupClientMethods() {
     let self = this;
     Meteor.methods({

--- a/lib/imports/api/prosemeteor/server/prosemeteor-server.js
+++ b/lib/imports/api/prosemeteor/server/prosemeteor-server.js
@@ -29,21 +29,5 @@ export class ProseMeteorServer {
       streamer: this.streamerServer,
       snapshotIntervalMs
     });
-
-    // set up Meteor methods
-    this.setupClientMethods();
-  }
-
-  /*
-  * Set up Meteor methods for communication with clients.
-  */
-  setupClientMethods() {
-    let self = this;
-    Meteor.methods({
-      'ProseMeteor.openDoc'({ docId }) {
-        check(docId, String);
-        self.authorityManager.openDoc({ docId });
-      }
-    });
   }
 }

--- a/lib/imports/startup/server/fixtures/document-fixture.js
+++ b/lib/imports/startup/server/fixtures/document-fixture.js
@@ -4,10 +4,9 @@ import { documentsColl } from './../../../api/documents/both/collection';
 
 // if the database is empty on server start, create some sample data.
 Meteor.startup(() => {
-  // create a single empty doc for the proof of concept. hard coding _id for now
-  documentsColl.remove({});
+  // documentsColl.remove({});
   if (documentsColl.find().count() === 0) {
-    // create two empty docs for the PoC, to show that AuthorityManager can handle multiple Authorities
+    // create two empty docs for the PoC, to show that AuthorityManager can handle multiple Authorities. hardcode ids for now
     createEmptyDoc.call({
       docId: 'proofOfConceptDocId1',
       textConcent: 'Demo 1, you can edit this text!'

--- a/lib/imports/startup/server/server-index.js
+++ b/lib/imports/startup/server/server-index.js
@@ -1,6 +1,2 @@
-import { ProseMeteorServer } from './../../api/prosemeteor/server/prosemeteor-server';
-
 // data fixtures
 import './fixtures/document-fixture';
-
-let proseMeteorServer = new ProseMeteorServer({ });

--- a/lib/imports/startup/server/server-index.js
+++ b/lib/imports/startup/server/server-index.js
@@ -1,32 +1,7 @@
-import { Meteor } from 'meteor/meteor';
-import { documentsColl } from './../../api/documents/both/collection'
-import { AuthorityManager } from './../../api/authority/server/authority-manager';
-import { check } from 'meteor/check';
+import { ProseMeteorServer } from './../../api/prosemeteor/server/prosemeteor-server';
+import { documentsColl } from './../../api/documents/both/collection';
 
 // data fixtures
 import './fixtures/document-fixture';
 
-// create streamer for event communication with client
-const streamerServer = new Meteor.Streamer('prosemirror-pipe', { retransmit : false });
-streamerServer.allowRead('all');
-streamerServer.allowWrite('all');
-
-// create an authority
-const authorityManager = new AuthorityManager({
-  documentsCollection: documentsColl,
-  streamer: streamerServer
-});
-
-// tell authority manager to open the single doc for the proof of concept, which
-// will create an authority to handle the doc
-
-
-// set up a method to let clients open a doc, which tells the AuthorityManager
-// to create a new Authority to start tracking the doc
-// NOTE: this should probably be moved somewhere else after PoC
-Meteor.methods({
-  'ProseMeteor.openDoc'({ docId }) {
-    check(docId, String);
-    authorityManager.openDoc({ docId });
-  }
-});
+let proseMeteorServer = new ProseMeteorServer({ documentsColl });

--- a/lib/imports/startup/server/server-index.js
+++ b/lib/imports/startup/server/server-index.js
@@ -1,7 +1,6 @@
 import { ProseMeteorServer } from './../../api/prosemeteor/server/prosemeteor-server';
-import { documentsColl } from './../../api/documents/both/collection';
 
 // data fixtures
 import './fixtures/document-fixture';
 
-let proseMeteorServer = new ProseMeteorServer({ documentsColl });
+let proseMeteorServer = new ProseMeteorServer({ });

--- a/lib/server/server-main.js
+++ b/lib/server/server-main.js
@@ -3,6 +3,4 @@ import './../imports/startup/server/server-index';
 
 import './../imports/api/documents/both/methods';
 
-import { ProseMeteorServer as ProseMeteorServerClass } from './../imports/api/prosemeteor/server/prosemeteor-server';
-
-export let ProseMeteorServer = ProseMeteorServerClass;
+export { ProseMeteorServer } from './../imports/api/prosemeteor/server/prosemeteor-server';

--- a/lib/server/server-main.js
+++ b/lib/server/server-main.js
@@ -2,3 +2,7 @@
 import './../imports/startup/server/server-index';
 
 import './../imports/api/documents/both/methods';
+
+import { ProseMeteorServer as ProseMeteorServerClass } from './../imports/api/prosemeteor/server/prosemeteor-server';
+
+export let ProseMeteorServer = ProseMeteorServerClass;


### PR DESCRIPTION
for #12 
- created a ProseMeteorServer class that instantiates all server code
- added snapshotIntervalMs to ProseMeteorServer constructor (not sure if it'll stay here in the long run, but it demonstrates that it can be changed and passed down to Authority instances)
- changed Authority to create an interval to write doc snapshots to db if changes have occurred since the last snapshot was written

The big change here is that all document steps are now persisted to db, so you can shut down the server and restart it and the document will still have its state. Previously it was only stored in memory. You'll see a message logged to server console for now that says when the write happened, so you can see when/if it writes. It should only happen if the interval is hit AND if changes have occurred since last snapshot.

@funkyeah 
