### PR TITLE
Fix/linting rules on

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
     "no-multiple-empty-lines": 2,
     "space-before-function-paren": 2,
     "no-var": 2,
-    "quotes": [2, "backtick"]
+    "quotes": [2, "backtick"],
+    "prefer-template": 2
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,13 +9,14 @@
   "rules": {
 
     "callback-return": 2,
-    "arrow-parens": 0,
+    "arrow-parens": 2,
     "semi": [
       2,
       "always"
     ],
-    "no-multiple-empty-lines": 0,
-    "space-before-function-paren": 0,
-    "no-var": 0
+    "no-multiple-empty-lines": 2,
+    "space-before-function-paren": 2,
+    "no-var": 2,
+    "quotes": [2, "backtick"]
   }
 }

--- a/lib/imports/api/authority/server/authority-manager.js
+++ b/lib/imports/api/authority/server/authority-manager.js
@@ -14,7 +14,7 @@ export class AuthorityManager {
   * @param {Number} params.snapshotIntervalMs   interval in millseconds that Authority will store a snapshot of an open doc to db
   * @constructor
   */
-  constructor({ documentsColl, streamer, snapshotIntervalMs }) {
+  constructor ({ documentsColl, streamer, snapshotIntervalMs }) {
     check(documentsColl, Mongo.Collection);
     check(streamer, Meteor.Streamer);
     check(snapshotIntervalMs, Number);
@@ -29,20 +29,20 @@ export class AuthorityManager {
   /**
   * Createds Meteor Methods to allow clients to communicate with the AuthorityManager.
   */
-  setupClientMethods() {
+  setupClientMethods () {
     let self = this;
 
     // NOTE: I wasn't sure how to make these ValidatedMethods, since a ValidatedMethod has to be imported
     // by the client. How can we make a ValidtedMethod that has access to AuthorityManager on server, but also can be imported by client?
     Meteor.methods({
       // allow clients to request latest doc state
-      'ProseMeteor.latestDocState'({ docId }) {
+      'ProseMeteor.latestDocState' ({ docId }) {
         check(docId, String);
         return self.latestDocState({ docId });
       },
 
       // allow clients to get new steps of a doc when they receieve the "authortiyNewSteps" event
-      'ProseMeteor.stepsSince'({ docId, version }) {
+      'ProseMeteor.stepsSince' ({ docId, version }) {
         check(docId, String);
         check(version, Number);
         // need to stringify so steps can be sent over the wire
@@ -50,7 +50,7 @@ export class AuthorityManager {
       },
 
       // allow clients to submit steps
-      'ProseMeteor.clientSubmitSteps'({ docId, clientId, version, stepsJSON }) {
+      'ProseMeteor.clientSubmitSteps' ({ docId, clientId, version, stepsJSON }) {
         check(docId, String);
         check(clientId, Number);
         check(version, Number);
@@ -59,7 +59,7 @@ export class AuthorityManager {
       },
 
       // open a doc, creating an authority for it
-      'ProseMeteor.openDoc'({ docId }) {
+      'ProseMeteor.openDoc' ({ docId }) {
         check(docId, String);
         self.openDoc({ docId });
       }
@@ -71,16 +71,16 @@ export class AuthorityManager {
   * @param {Object} params
   * @param {String} params.docId       the unique id of the doc
   */
-  openDoc({ docId }) {
+  openDoc ({ docId }) {
     check(docId, String);
     if (!docId) {
-      throw new Meteor.Error('AuthorityManager.openDoc.nonexistant', 'This AuthorityManager doesn\'t have an Authority tracking a document with docId "' + docId + '".');
+      throw new Meteor.Error(`AuthorityManager.openDoc.nonexistant`, `This AuthorityManager doesn't have an Authority tracking a document with docId ${docId}.`);
     }
     // if we're already tracking this doc with an authority, we're all set
     if (this.authorities[docId]) {
       return docId;
     }
-    console.log('AuthorityManager opening doc ' + docId + ', creating new authority');
+    console.log(`AuthorityManager opening doc ${docId}, creating new authority`);
     // create a new authority
     this.authorities[docId] = new Authority({
       docId,
@@ -95,10 +95,10 @@ export class AuthorityManager {
    * Return the latest state of the document in memory from its corresponding Authority.
    * @return {{ version: Number, docJSON: Object}}
    */
-  latestDocState({ docId }) {
+  latestDocState ({ docId }) {
     check(docId, String);
     if (!this.authorities[docId]) {
-      throw new Meteor.Error('AuthorityManager.latestDocState.nonexistant', 'This AuthorityManager doesn\'t have an Authority tracking a document with docId "' + docId + '".');
+      throw new Meteor.Error(`AuthorityManager.latestDocState.nonexistant`, `This AuthorityManager doesn't have an Authority tracking a document with docId ${docId}.`);
     }
     return this.authorities[docId].latestDocState();
   }
@@ -109,11 +109,11 @@ export class AuthorityManager {
   * @param {Number} params.version        doc version to request steps since
   * @param {String} params.docId          id of the doc
   */
-  stepsSince({ version, docId }) {
+  stepsSince ({ version, docId }) {
     check(version, Number);
     check(docId, String);
     if (!this.authorities[docId]) {
-      throw new Meteor.Error('AuthorityManager.stepsSince.nonexistant', 'This AuthorityManager doesn\'t have an Authority tracking a document with docId "' + docId + '".');
+      throw new Meteor.Error(`AuthorityManager.stepsSince.nonexistant`, `This AuthorityManager doesn't have an Authority tracking a document with docId ${docId}.`);
     }
     return this.authorities[docId].stepsSince({ version });
   }
@@ -126,13 +126,13 @@ export class AuthorityManager {
   * @param {Number} params.clientId       client id used by ProseMirror
   * @param {Array} params.stepsJSON       steps to be received, in JS object/array form (not yet Step instances)
   */
-  receiveSteps({ docId, version, stepsJSON, clientId }) {
+  receiveSteps ({ docId, version, stepsJSON, clientId }) {
     check(docId, String);
     check(version, Number);
     check(stepsJSON, Array);
     check(clientId, Number);
     if (!this.authorities[docId]) {
-      throw new Meteor.Error('AuthorityManager.receiveSteps.nonexistant', 'This AuthorityManager doesn\'t have an Authority tracking a document with docId "' + docId + '".');
+      throw new Meteor.Error(`AuthorityManager.receiveSteps.nonexistant`, `This AuthorityManager doesn't have an Authority tracking a document with docId ${docId}.`);
     }
     this.authorities[docId].receiveSteps({ clientId, version, stepsJSON });
     //     this.authorities[docId].receiveSteps.bind(this.authorities[docId], { clientId, version, stepsJSON });

--- a/lib/imports/api/authority/server/authority.js
+++ b/lib/imports/api/authority/server/authority.js
@@ -17,12 +17,12 @@ export class Authority {
    * @param {Number} params.snapshotIntervalMs       interval in millseconds that Authority will store a snapshot of an open doc to db
    * @constructor
    */
-  constructor({ docId, documentsColl, streamer, snapshotIntervalMs }) {
+  constructor ({ docId, documentsColl, streamer, snapshotIntervalMs }) {
     check(docId, String);
     check(documentsColl, Mongo.Collection);
     check(streamer, Meteor.Streamer);
     check(snapshotIntervalMs, Number);
-    console.log('Authority created for doc id: ' + docId);
+    console.log(`Authority created for doc id: ${docId}`);
     this.docId = docId;
     this.documentsColl = documentsColl;
     this.streamerServer = streamer;
@@ -33,10 +33,10 @@ export class Authority {
       docId: this.docId
     }, (err, res) => {
       if (err) {
-        throw new Meteor.Error(500, 'Authority error getting latest snapshot for doc ' + this.docId + ':' + err);
+        throw new Meteor.Error(500, `Authority error getting latest snapshot for doc ${this.docId}: ${err}`);
       }
       let { docJSON } = res;
-      console.log('Authority got latest snapshot for doc ' + this.docId + ':', JSON.stringify(res, null, 2));
+      console.log(`Authority got latest snapshot for doc ${this.docId}: ${JSON.stringify(res, null, 2)}`);
 
       this.doc = defaultSchema.nodeFromJSON(docJSON);
       this.steps = [];
@@ -54,7 +54,7 @@ export class Authority {
    * Return the latest state of the document in memory
    * @return {{ version: Number, docJSON: Object}}
    */
-  latestDocState() {
+  latestDocState () {
     return {
       version: this.version(),
       docJSON: this.doc.toJSON()
@@ -68,7 +68,7 @@ export class Authority {
   * @param {Array} params.stepsJSON       steps to be received, in JS object/array form (not yet Step instances)
   * @param {Number} params.version        doc version the client is submitting for
   */
-  receiveSteps({ clientId, stepsJSON, version }) {
+  receiveSteps ({ clientId, stepsJSON, version }) {
     check(clientId, Number);
     check(stepsJSON, Array);
     check(version, Number);
@@ -77,12 +77,12 @@ export class Authority {
     const stepObjects = stepsJSON.map((step) => {
       return Step.fromJSON(defaultSchema, step);
     });
-    console.log('Authority received ' + stepsJSON.length + ' steps from client ' + clientId + ' for doc version ' + version);
+    console.log(`Authority received ${stepsJSON.length} steps from client ${clientId} for doc version ${version}`);
 
     // if the client submitted steps but that client didn't have the latest version
     // of the doc, stop since they must be applied to newest doc version
     if (version !== currentDocVersion) {
-      console.log('client ' + clientId + 'didn\'t have the latest version, Authority not accepting changes');
+      console.log(`client ${clientId} didn't have the latest version, Authority not accepting changes`);
       return;
     }
     // apply and accumulate new steps
@@ -92,8 +92,8 @@ export class Authority {
       this.stepClientIds.push(new CollabStepClientId({ versionAppliedTo: currentDocVersion, clientId }));
     });
     // notify listening clients that new steps have arrived
-    console.log('Authority notifying clients of new steps');
-    this.streamerServer.emit('authorityNewSteps');
+    console.log(`Authority notifying clients of new steps`);
+    this.streamerServer.emit(`authorityNewSteps`);
   }
 
   /**
@@ -102,7 +102,7 @@ export class Authority {
    * @param {Number} params.version    version of the document
    * @return {Object} stepsSince  object with "steps" array and "clientIds" array
    */
-  stepsSince({ version }) {
+  stepsSince ({ version }) {
     check(version, Number);
     let steps = [];
     let clientIds = [];
@@ -126,13 +126,13 @@ export class Authority {
   /**
   * Starts the timer interval to store doc snapshots to db.
   */
-  startSnapshotInterval() {
+  startSnapshotInterval () {
     this.snapshotIntervalTimer = Meteor.setInterval(() => {
       // only store snapshot if changes have occurred since last snapshot
       let latestSnapshotVersion = this.latestSnapshot.version;
       let version = this.version();
       if (version > latestSnapshotVersion) {
-        console.log('Authority storing snapshot for doc "' + this.docId + '", version ' + version);
+        console.log(`Authority storing snapshot for doc ${this.docId}, version ${version}`);
         this.storeSnapshot();
       }
     }, this.snapshotIntervalMs);
@@ -141,7 +141,7 @@ export class Authority {
   /**
   * Clears the snapshot interval.
   */
-  stopSnapshotInterval() {
+  stopSnapshotInterval () {
     Meteor.clearInterval(this.snapshotIntervalTimer);
   }
 
@@ -149,7 +149,7 @@ export class Authority {
   * Returns the version number of this Authority's document.
   * @returns {Number}
   */
-  version() {
+  version () {
     let version;
     if (this.numberOfSnapshots === 0) {
       version = this.steps.length;
@@ -164,7 +164,7 @@ export class Authority {
   /**
    * Store a snapshot of the current document in the documentsColl
    */
-  storeSnapshot() {
+  storeSnapshot () {
     const newSnapshot = {
       docId: this.docId,
       docJSON: this.doc.toJSON(),

--- a/lib/imports/api/authority/server/collab-step-client-id.js
+++ b/lib/imports/api/authority/server/collab-step-client-id.js
@@ -7,7 +7,7 @@ export class CollabStepClientId {
   * @param {Number} params.versionAppliedTo   the version this step was applied to
   * @param {Number} params.clientId           the ProseMirror Step instance
   */
-  constructor({ versionAppliedTo, clientId }) {
+  constructor ({ versionAppliedTo, clientId }) {
     check(versionAppliedTo, Number);
     check(clientId, Number);
     this.versionAppliedTo = versionAppliedTo;

--- a/lib/imports/api/authority/server/collab-step.js
+++ b/lib/imports/api/authority/server/collab-step.js
@@ -8,7 +8,7 @@ export class CollabStep {
   * @param {Number} params.versionAppliedTo   the version this step was applied to
   * @param {Object} params.step           the ProseMirror Step instance
   */
-  constructor({ versionAppliedTo, step }) {
+  constructor ({ versionAppliedTo, step }) {
     check(versionAppliedTo, Number);
     check(step, Step);
     this.versionAppliedTo = versionAppliedTo;

--- a/lib/imports/api/collab-editor/client/collab-editor.js
+++ b/lib/imports/api/collab-editor/client/collab-editor.js
@@ -8,10 +8,10 @@ import { defaultSchema } from './../../../prosemirror/dist/model/defaultschema';
 import { Step } from './../../../prosemirror/dist/transform';
 
 // share a global streamerClient across all CollabEditors
-const streamerClient = new Meteor.Streamer('prosemirror-pipe');
+const streamerClient = new Meteor.Streamer(`prosemirror-pipe`);
 
 export default class CollabEditor {
-  constructor({ docId, proseMirrorOptions }) {
+  constructor ({ docId, proseMirrorOptions }) {
     this.docId = docId;
     this.proseMirrorOptions = proseMirrorOptions;
     this.streamerClient = streamerClient;
@@ -21,26 +21,26 @@ export default class CollabEditor {
   /**
   * Gets the latest doc state and creates an editor with it.
   */
-  setupEditor() {
+  setupEditor () {
     let self = this;
 
     // tell the AuthorityManager to open the doc
-    Meteor.call('ProseMeteor.openDoc', {
+    Meteor.call(`ProseMeteor.openDoc`, {
       docId: self.docId
-    }, function(err) {
+    }, function (err) {
       if (err) {
-        console.error('CollabEditor authority openDoc error:', err);
+        console.error(`CollabEditor authority openDoc error:`, err);
         // TODO: handle error
       }
       // the authority is ready. get the latest doc state
-      Meteor.call('ProseMeteor.latestDocState', {
+      Meteor.call(`ProseMeteor.latestDocState`, {
         docId: self.docId
       }, function (err, latestDocState) {
         if (err) {
-          console.error('CollabEditor get latestDocState error:', err);
+          console.error(`CollabEditor get latestDocState error:`, err);
           // TODO: handle error
         }
-        console.log('CollabEditor got latestDocState:', latestDocState);
+        console.log(`CollabEditor got latestDocState:`, latestDocState);
 
         // create an editor with the latest state
         self.createEditor(latestDocState);
@@ -54,8 +54,8 @@ export default class CollabEditor {
   * @param {Number} params.version     the doc's current version
   * @param {Object} params.docJSON     the doc's state represented as JS object
   */
-  createEditor({ version, docJSON }) {
-    console.log('Creating collab editor with doc version: ' + version);
+  createEditor ({ version, docJSON }) {
+    console.log(`Creating collab editor with doc version: ${version}`);
     this.editor = new ProseMirror({
       ...this.proseMirrorOptions,
       collab: {
@@ -66,15 +66,15 @@ export default class CollabEditor {
     this.collab = this.editor.mod.collab;
 
     // respond to collab send event by sending local steps to authority
-    this.collab.on('mustSend', this.sendStepsToAuthority.bind(this));
+    this.collab.on(`mustSend`, this.sendStepsToAuthority.bind(this));
 
     // when authortiy tells us there's new steps, receieve them
-    this.streamerClient.on('authorityNewSteps', this.receieveNewStepsFromAuthority.bind(this));
+    this.streamerClient.on(`authorityNewSteps`, this.receieveNewStepsFromAuthority.bind(this));
   }
 
-  sendStepsToAuthority() {
+  sendStepsToAuthority () {
     const data = this.collab.sendableSteps();
-    console.log('CollabEditor sendStepsToAuthority(), data=', data);
+    console.log(`CollabEditor sendStepsToAuthority(), data=`, data);
     // convert to JSON so we can send it over the wire
     const stepsJSON = data.steps.map((step) => {
       return step.toJSON();
@@ -82,7 +82,7 @@ export default class CollabEditor {
 
     let self = this;
 
-    Meteor.call('ProseMeteor.clientSubmitSteps', {
+    Meteor.call(`ProseMeteor.clientSubmitSteps`, {
       docId: self.docId,
       version: data.version,
       stepsJSON,
@@ -90,19 +90,19 @@ export default class CollabEditor {
     });
   }
 
-  receieveNewStepsFromAuthority() {
+  receieveNewStepsFromAuthority () {
     let self = this;
     // get the steps since local version from authority
-    Meteor.call('ProseMeteor.stepsSince', {
+    Meteor.call(`ProseMeteor.stepsSince`, {
       docId: self.docId,
       version: self.collab.version
     }, function (err, newData) {
       if (err) {
-        console.error('CollabEditor get steps from Authority since v' + self.collab.version + ' error:', err);
+        console.error(`CollabEditor get steps from Authority since v${self.collab.version}, error: ${err}`);
         // TODO: handle error
       }
       let parsedNewData = JSON.parse(newData);
-      console.log('CollabEditor got steps from Authority since v' + self.collab.version);
+      console.log(`CollabEditor got steps from Authority since v${self.collab.version}`);
 
       let { steps, clientIds } = parsedNewData;
       // convert steps to Step instances

--- a/lib/imports/api/documents/both/collection.js
+++ b/lib/imports/api/documents/both/collection.js
@@ -1,13 +1,13 @@
 import { Mongo } from 'meteor/mongo';
 
 // todo: the collection name and field names should probably be configurable
-export const documentsColl = new Mongo.Collection('Documents');
+export const documentsColl = new Mongo.Collection(`Documents`);
 
 // Deny all client-side updates since we will be using methods to manage this collection
 documentsColl.deny({
-  insert() { return true; },
-  update() { return true; },
-  remove() { return true; }
+  insert () { return true; },
+  update () { return true; },
+  remove () { return true; }
 });
 
 // class Documents extends Mongo.Collection {

--- a/lib/imports/api/documents/both/methods.js
+++ b/lib/imports/api/documents/both/methods.js
@@ -24,8 +24,8 @@ import { ValidatedMethod } from 'meteor/mdg:validated-method';
 // });
 
 export const createEmptyDoc = new ValidatedMethod({
-  name: 'documents.createEmptyDoc',
-  validate(args) {
+  name: `documents.createEmptyDoc`,
+  validate (args) {
     check(args, {
       // can provide docId as string, or leave empty
       docId: Match.Optional(String),
@@ -33,10 +33,10 @@ export const createEmptyDoc = new ValidatedMethod({
       textConcent: Match.Optional(String)
     });
   },
-  run(args) {
+  run (args) {
     // create an empty doc with version 0
-    let fixtureDoc = schema.node('doc', null, [schema.node('paragraph', null, [
-      schema.text(args.textConcent || 'You can edit this text!')
+    let fixtureDoc = schema.node(`doc`, null, [schema.node(`paragraph`, null, [
+      schema.text(args.textConcent || `You can edit this text!`)
     ])]);
     let fixtureDocJSON = fixtureDoc.toJSON();
 
@@ -55,20 +55,20 @@ export const createEmptyDoc = new ValidatedMethod({
       _id,
       ...documentSnapshot
     };
-    console.log('Inserted the following doc into the Documents collection:');
+    console.log(`Inserted the following doc into the Documents collection:`);
     console.log(JSON.stringify(snapshotWithId, null, 2));
     return snapshotWithId;
   }
 });
 
 export const getLatestDocSnapshot = new ValidatedMethod({
-  name: 'documents.getLatestDocSnapshot',
-  validate(args) {
+  name: `documents.getLatestDocSnapshot`,
+  validate (args) {
     check(args, {
       docId: String
     });
   },
-  run({ docId }) {
+  run ({ docId }) {
     return documentsColl.findOne({ docId }, { sort: { timestamp: -1 } });
   }
 });

--- a/lib/imports/api/prosemeteor/server/prosemeteor-server.js
+++ b/lib/imports/api/prosemeteor/server/prosemeteor-server.js
@@ -2,7 +2,6 @@ import { Meteor } from 'meteor/meteor';
 import { AuthorityManager } from './../../authority/server/authority-manager';
 import { documentsColl } from './../../documents/both/collection';
 
-
 /**
 * Main ProseMeteor server class that instantiates all of ProseMeteor on the server.
 */
@@ -14,13 +13,13 @@ export class ProseMeteorServer {
   * @param {Number} [params.snapshotIntervalMs]  interval in milliseconds that documents are backed up to a snapshot in db
   * @constructor
   */
-  constructor({ snapshotIntervalMs = 5000 }) {
+  constructor ({ snapshotIntervalMs = 5000 }) {
     // store documents collection
     this.documentsColl = documentsColl;
     // create streamer for event communication with client
-    this.streamerServer = new Meteor.Streamer('prosemirror-pipe', { retransmit: false });
-    this.streamerServer.allowRead('all');
-    this.streamerServer.allowWrite('all');
+    this.streamerServer = new Meteor.Streamer(`prosemirror-pipe`, { retransmit: false });
+    this.streamerServer.allowRead(`all`);
+    this.streamerServer.allowWrite(`all`);
 
     // create authority manager  to create, delete authorities and communicate with clients
     this.authorityManager = new AuthorityManager({

--- a/lib/imports/startup/client/client-index.js
+++ b/lib/imports/startup/client/client-index.js
@@ -1,4 +1,4 @@
 // Meteor.startup(() => {
 //   // code to run on server at startup
 // });import './prosemirrorAPI.js';
-console.log('prosemeteor client startup');
+console.log(`prosemeteor client startup`);

--- a/lib/imports/startup/server/fixtures/document-fixture.js
+++ b/lib/imports/startup/server/fixtures/document-fixture.js
@@ -8,20 +8,20 @@ Meteor.startup(() => {
   if (documentsColl.find().count() === 0) {
     // create two empty docs for the PoC, to show that AuthorityManager can handle multiple Authorities. hardcode ids for now
     createEmptyDoc.call({
-      docId: 'proofOfConceptDocId1',
-      textConcent: 'Demo 1, you can edit this text!'
+      docId: `proofOfConceptDocId1`,
+      textConcent: `Demo 1, you can edit this text!`
     }, (err, res) => {
       if (err) {
-        console.error('Error while inserting empty doc:', err);
+        console.error(`Error while inserting empty doc:`, err);
       }
     });
 
     createEmptyDoc.call({
-      docId: 'proofOfConceptDocId2',
-      textConcent: 'Demo 2, you can edit this text!'
+      docId: `proofOfConceptDocId2`,
+      textConcent: `Demo 2, you can edit this text!`
     }, (err, res) => {
       if (err) {
-        console.error('Error while inserting empty doc:', err);
+        console.error(`Error while inserting empty doc:`, err);
       }
     });
   }

--- a/lib/tests/prosemirror-tests.js
+++ b/lib/tests/prosemirror-tests.js
@@ -6,10 +6,9 @@ import { name as packageName } from 'meteor/prosemirror';
 
 // Write your tests here!
 // Here is an example.
-Tinytest.add('prosemirror - example', function (test) {
-  test.equal(packageName, 'prosemirror');
+Tinytest.add(`prosemirror - example`, function (test) {
+  test.equal(packageName, `prosemirror`);
 });
-
 
 // test for Prosepipe setup
 // test for Prosemirror setup


### PR DESCRIPTION
I accidentally had set some linting rules set to 0 (off) instead of the proper 2 (error). This fixes that, and also adds two rules to prefer backticks for strings (string templates new to es2015) and prefers string templates for including variables instead of string concatenation. Most of the changes were done automatically via `npm run lint:fix`.

@funkyeah @ellery44 
