### PR TITLE
Feature/authority registry

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,6 @@
     "no-multiple-empty-lines": 2,
     "space-before-function-paren": 2,
     "no-var": 2,
-    "quotes": [2, "backtick"],
     "prefer-template": 2
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,6 @@
     "standard"
   ],
   "rules": {
-
     "callback-return": 2,
     "arrow-parens": 0,
     "semi": [

--- a/.npm/package/.gitignore
+++ b/.npm/package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.npm/package/README
+++ b/.npm/package/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "ip": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.3.tgz",
+      "from": "ip@1.1.3"
+    }
+  }
+}

--- a/demo/server/main.js
+++ b/demo/server/main.js
@@ -6,4 +6,7 @@ Meteor.startup(() => {
 });
 
 // setup ProseMeteor on server
-let proseMeteorServer = new ProseMeteorServer({ snapshotIntervalMs: 5000 });
+let proseMeteorServer = new ProseMeteorServer({
+  snapshotIntervalMs: 5000,
+  protocol: 'http'
+ });

--- a/lib/imports/api/authority-registry/server/authority-registry.js
+++ b/lib/imports/api/authority-registry/server/authority-registry.js
@@ -1,5 +1,8 @@
+// import ip from 'ip';
+
 export class AuthorityRegistry {
-  registerAuthority({ authorityIp }) {
+  registerAuthority() {
+    // let authorityIp = ip.address();
     // insert { authorityIp, docIds: [] } into collection
   }
   unregisterAuthority({ authorityIp }) {

--- a/lib/imports/api/authority-registry/server/authority-registry.js
+++ b/lib/imports/api/authority-registry/server/authority-registry.js
@@ -261,7 +261,7 @@ export class AuthorityRegistry {
   * @returns {{}} authority
   */
   getAuthorityInfoByGroupId ({ groupId }) {
-    return authorityRegistryColl.findOne({ groupId: groupId });
+    return authorityRegistryColl.findOne({ groupIds: groupId });
   }
   /**
   *  Returns if the specified server is registered or not.

--- a/lib/imports/api/authority-registry/server/authority-registry.js
+++ b/lib/imports/api/authority-registry/server/authority-registry.js
@@ -15,12 +15,29 @@ import ip from 'ip';
 const HTTPS_PORT = 443;
 const HEALTH_CHECK_RESPONSE = 'ProseMeteor Health OK';
 const FAILED_HEALTH_CHECKS_THRESHOLD = 5;
-const HEALTH_CHECK_INTERVAL_MS = 1000 * 10;   // interval on which to run health checks
+const HEALTH_CHECK_INTERVAL_MS = 1000 * 30;   // interval on which to run health checks
 
 export class AuthorityRegistry {
   constructor () {
     this.ip = ip.address();
     this.port = parseInt(process.env.PORT);
+
+    const fullUrl = `${this.ip}:${this.port}`;
+    this.fullUrlWithProtocol = (this.port === HTTPS_PORT) ? `https://${fullUrl}` : `http://${fullUrl}`;
+    console.log(`ProseMeteor AuthorityRegistry, this server url: ${this.fullUrlWithProtocol}`);
+
+    // bind class methods
+    this.setUpHealthCheckEndpoint = this.setUpHealthCheckEndpoint.bind(this);
+    this.setupClientMethods = this.setupClientMethods.bind(this);
+    this.startHealthCheckInterval = this.startHealthCheckInterval.bind(this);
+    this.register = this.register.bind(this);
+    this.unregister = this.unregister.bind(this);
+    this.runHealthChecks = this.runHealthChecks.bind(this);
+    this.fullRegistry = this.fullRegistry.bind(this);
+    this.isRegistered = this.isRegistered.bind(this);
+    this.getUrlOfAuthorityHostingDoc = this.getUrlOfAuthorityHostingDoc.bind(this);
+    this.chooseAuthorityToHostDoc = this.chooseAuthorityToHostDoc.bind(this);
+
     this.setUpHealthCheckEndpoint();
     this.startHealthCheckInterval();
     this.setupClientMethods();
@@ -59,7 +76,7 @@ export class AuthorityRegistry {
   */
   startHealthCheckInterval () {
     Meteor.setInterval(() => {
-      this.runHealthChecks();
+      this.runHealthChecks(this.fullRegistry());
     }, HEALTH_CHECK_INTERVAL_MS);
   }
   /**
@@ -79,7 +96,7 @@ export class AuthorityRegistry {
         return cb(null, res);
       });
       // at the same time, start the health checks on all other servers
-      this.runHealthChecks();
+      this.runHealthChecks(this.fullRegistry());
     };
     // check if this sever's already registered first
     if (this.isRegistered({ ip: this.ip, port: this.port })) {
@@ -114,20 +131,38 @@ export class AuthorityRegistry {
       return cb(null, res);
     });
   }
+
+  /**
+  * Runs a health check against a single server.
+  * @param {Object} params
+  * @param {String} params.authorityUrl     url of the authority
+  * @param {Function} cb                  callback, given Boolean of if health check passed
+  */
+  runSingleHealthCheck ({ authorityUrl }, cb) {
+    const authority = this.getAuthority({ authorityUrl });
+    // run health check. if number of failed === 0, it was healthy
+    const numFailed = this.runHealthChecks([ authority ]);
+    const passed = numFailed === 0;
+    console.log(`ProseMeteor AuthorityRegistry: ran single health check for ${authorityUrl}, passed=${passed}, numFailed=${numFailed}`);
+    return passed;
+  }
   /**
   *  Run health checks against every server in the registry, keeping track of which have failed
   * and removing those that have failed more than the threshold.
+  * @param {Array} serversArray   array of server objects with { _id, {String} ip, {Number} port, {Number} failedHealthChecks}
+  * @param {Function} cb          callback, with number of failed connections passed to it
+  * @returns {Number} number of failed connections
   */
-  runHealthChecks () {
-    const fullRegistry = this.fullRegistry();
-    const numServers = fullRegistry.length;
+  runHealthChecks (serversArray) {
+    const numServers = serversArray.length;
     let failedConnections = [];                       // _ids of all servers that failed checks, that didn't pass the threshold
     let failedConnectionsAboveThreshold = [];         // _ids of all servers that failed checks, that did pass the threshold
     let successfullChecksThatFailedPreviously = [];   // _ids of all servers that had a previous failure but passed this time, without passing the threshold
     console.log(`ProseMeteor AuthorityRegistry: Starting health checks for ${numServers} servers at time: ${new Date()}`);
-    console.log(`Full registry: ${JSON.stringify(fullRegistry, null, 2)}`);
+    console.log(`Health checks server array: ${JSON.stringify(serversArray, null, 2)}`);
     // do a check on each server
-    fullRegistry.forEach(({ _id, ip, port, failedHealthChecks }) => {
+    serversArray.forEach(({ _id, ip, port, fullUrl, failedHealthChecks }) => {
+      console.log(`ProseMeteor AuthorityRegistry: running health check against ${fullUrl}`);
       if (ip === this.ip && port === this.port) {
         console.log('ProseMeteor AuthorityRegistry: Skipping this server\'s health check');
         return;
@@ -161,34 +196,38 @@ export class AuthorityRegistry {
         }
       }
     });
-    console.log(`ProseMeteor AuthorityRegistry: Finished health checks. failed connections (${failedConnections.length} of ${numServers}): ${failedConnections}`);
+    console.log(`ProseMeteor AuthorityRegistry: Finished health checks. failed connections (${failedConnections.length} of ${numServers}): ${JSON.stringify(failedConnections, null, 2)}`);
+    console.log(`ProseMeteor AuthorityRegistry: Finished health checks. failedConnectionsAboveThreshold: ${JSON.stringify(failedConnectionsAboveThreshold, null, 2)}`);
     // store any failures
     if (failedConnections.length > 0) {
-      storeFailedHealthChecks.call({ _ids: failedConnections }, (err, res) => {
-        if (err) {
-          console.log(`ProseMeteor AuthorityRegistry: Failed to store failed health checks: ${err}`);
-        }
+      try {
+        storeFailedHealthChecks.call({ _ids: failedConnections });
         console.log('ProseMeteor AuthorityRegistry: Successfully stored failed health checks');
-      });
-    }
-    // remove servers that have failed too many health checks
-    if (failedConnectionsAboveThreshold.length > 0) {
-      removeAuthorities.call({ _ids: failedConnectionsAboveThreshold }, (err) => {
-        if (err) {
-          console.log(`ProseMeteor AuthorityRegistry: Failed to remove authorities ${failedConnectionsAboveThreshold}: ${err}`);
-        }
-        console.log(`ProseMeteor AuthorityRegistry: Removed ${failedConnectionsAboveThreshold.length} authorities from the registry because of failed health checks`);
-      });
+      } catch (e) {
+        console.log(`ProseMeteor AuthorityRegistry: Failed to store failed health checks: ${e}`);
+      }
     }
     // reset failed health check count on servers that failed < threshold previously, and now passed
     if (successfullChecksThatFailedPreviously.length > 0) {
-      resetFailedHealthChecksCount.call({ _ids: successfullChecksThatFailedPreviously }, (err) => {
-        if (err) {
-          console.log(`ProseMeteor AuthorityRegistry: Failed to reset the failed health checks count for ${successfullChecksThatFailedPreviously.length} servers: ${err}`);
-        }
+      try {
+        resetFailedHealthChecksCount.call({ _ids: successfullChecksThatFailedPreviously });
         console.log(`ProseMeteor AuthorityRegistry: Reset the failed health checks count for ${successfullChecksThatFailedPreviously.length} servers: ${successfullChecksThatFailedPreviously}`);
-      });
+      } catch (e) {
+        console.log(`ProseMeteor AuthorityRegistry: Failed to reset the failed health checks count for ${successfullChecksThatFailedPreviously.length} servers: ${e}`);
+      }
     }
+    // remove servers that have failed too many health checks
+    if (failedConnectionsAboveThreshold.length > 0) {
+      try {
+        removeAuthorities.call({ _ids: failedConnectionsAboveThreshold });
+        console.log(`ProseMeteor AuthorityRegistry: Removed ${failedConnectionsAboveThreshold.length} authorities from the registry because of failed health checks`);
+      } catch (e) {
+        console.log(`ProseMeteor AuthorityRegistry: Failed to remove authorities ${failedConnectionsAboveThreshold}: ${e}`);
+      }
+    }
+
+    // return total number of bad connections, combining failedConnections with failedConnectionsAboveThreshold
+    return failedConnections.concat(failedConnectionsAboveThreshold).length;
   }
   /**
   *  Returns the full authority registry from the database.
@@ -196,6 +235,16 @@ export class AuthorityRegistry {
   */
   fullRegistry () {
     return authorityRegistryColl.find({}).fetch();
+  }
+
+  /**
+  *  Returns a single authority from the registry database.
+  * @param {Object} params
+  * @param {String} params.authorityUrl     full url of the authority to find (protocol:ip:port)
+  * @returns {{}} authority
+  */
+  getAuthority ({ authorityUrl }) {
+    return authorityRegistryColl.findOne({ fullUrl: authorityUrl });
   }
   /**
   *  Returns if the specified server is registered or not.

--- a/lib/imports/api/authority-registry/server/authority-registry.js
+++ b/lib/imports/api/authority-registry/server/authority-registry.js
@@ -12,7 +12,7 @@ export class AuthorityRegistry {
       });
     };
 
-    if (this.isRegistered({ ip })) {
+    if (this.isRegistered({ ip, port })) {
       console.log(`Authority server is already registered, clearing it out`);
       removeAuthority.call({ ip }, (err, res) => {
         if (err) {
@@ -24,9 +24,9 @@ export class AuthorityRegistry {
       return insert();
     }
   }
-  unregister ({ ip }, cb) {
+  unregister ({ ip, port }, cb) {
     // remove from collection
-    removeAuthority.call({ ip }, (err, res) => {
+    removeAuthority.call({ ip, port }, (err, res) => {
       if (err) {
         return cb(new Error(`Failed to remove Authority server from registry: ${err}`));
       }
@@ -34,8 +34,9 @@ export class AuthorityRegistry {
       return cb(null, res);
     });
   }
-  isRegistered ({ ip }) {
-    return authorityRegistryColl.find({ ip }).count() !== 0;
+
+  isRegistered ({ ip, port }) {
+    return authorityRegistryColl.find({ ip, port }).count() !== 0;
   }
 
   addDocToAuthority ({ ip, docId }) {

--- a/lib/imports/api/authority-registry/server/authority-registry.js
+++ b/lib/imports/api/authority-registry/server/authority-registry.js
@@ -1,4 +1,10 @@
-import { insertAuthority, removeAuthority, storeFailedHealthChecks, removeAuthorities } from './methods';
+import {
+  insertAuthority,
+  removeAuthority,
+  storeFailedHealthChecks,
+  removeAuthorities,
+  resetFailedHealthChecksCount
+} from './methods';
 import { authorityRegistryColl } from './collection';
 import { WebApp } from 'meteor/webapp';
 import { HTTP } from 'meteor/http';
@@ -54,8 +60,9 @@ export class AuthorityRegistry {
   runHealthChecks ({ thisServerIp, thisServerPort }) {
     const fullRegistry = this.fullRegistry();
     const numServers = fullRegistry.length;
-    let failedConnections = [];
-    let failedConnectionsAboveThreshold = [];
+    let failedConnections = [];                       // _ids of all servers that failed checks, that didn't pass the threshold
+    let failedConnectionsAboveThreshold = [];         // _ids of all servers that failed checks, that did pass the threshold
+    let successfullChecksThatFailedPreviously = [];   // _ids of all servers that had a previous failure but passed this time, without passing the threshold
     console.log(`ProseMeteor AuthorityRegistry: Starting health checks for ${numServers} servers`);
     // do a check on each server
     fullRegistry.forEach(({ _id, ip, port, failedHealthChecks }) => {
@@ -72,34 +79,35 @@ export class AuthorityRegistry {
       const healthCheckUrl = `${ip}:${port}/prosemeteor-health-check`;
       const httpUrl = `http://${healthCheckUrl}`;
       const httpsUrl = `https://${healthCheckUrl}`;
-      let httpRes;
-      let httpsRes;
+      let httpRes, httpsRes;
       let httpFailed = false;
       let httpsFailed = false;
       try {
         httpRes = HTTP.get(httpUrl);
+        if (httpRes !== `ProseMeteor Health OK`) {
+          httpFailed = true;
+        }
       } catch (e) {
-        // console.log(`ProseMeteor AuthorityRegistry: httpRes failed ${e}`);
         httpFailed = true;
       }
       try {
         httpsRes = HTTP.get(httpsUrl);
+        if (httpsRes !== `ProseMeteor Health OK`) {
+          httpsFailed = true;
+        }
       } catch (e) {
-        // console.log(`ProseMeteor AuthorityRegistry: httpsRes failed ${e}`);
         httpsFailed = true;
-      }
-      if (httpRes) {
-        // console.log(`ProseMeteor AuthorityRegistry: ---http res: ${httpRes}`);
-      }
-      if (httpsRes) {
-        // console.log(`ProseMeteor AuthorityRegistry: ---https res: ${httpsRes}`);
       }
       if (httpFailed && httpsFailed) {
         failedConnections.push(_id);
+      } else {
+        // if this server failed a previous health check but passed this time, mark it to reset its failedHealthChecks count
+        if (failedConnections > 0) {
+          successfullChecksThatFailedPreviously.push(_id);
+        }
       }
     });
     console.log(`ProseMeteor AuthorityRegistry: Finished health checks. failed connections (${failedConnections.length} of ${numServers}): ${failedConnections}`);
-
     // store any failures
     if (failedConnections.length > 0) {
       storeFailedHealthChecks.call({ _ids: failedConnections }, (err, res) => {
@@ -109,13 +117,22 @@ export class AuthorityRegistry {
         console.log(`ProseMeteor AuthorityRegistry: Successfully stored failed health checks`);
       });
     }
-    if (failedConnectionsAboveThreshold.length > 0) {
     // remove servers that have failed too many health checks
+    if (failedConnectionsAboveThreshold.length > 0) {
       removeAuthorities.call({ _ids: failedConnectionsAboveThreshold }, (err) => {
         if (err) {
           console.log(`ProseMeteor AuthorityRegistry: Failed to remove authorities ${failedConnectionsAboveThreshold}: ${err}`);
         }
         console.log(`ProseMeteor AuthorityRegistry: Removed ${failedConnectionsAboveThreshold.length} authorities from the registry because of failed health checks`);
+      });
+    }
+    // reset failed health check count on servers that failed < threshold previously, and now passed
+    if (successfullChecksThatFailedPreviously.length > 0) {
+      resetFailedHealthChecksCount.call({ _ids: successfullChecksThatFailedPreviously }, (err) => {
+        if (err) {
+          console.log(`ProseMeteor AuthorityRegistry: Failed to reset the failed health checks count for ${successfullChecksThatFailedPreviously.length} servers: ${err}`);
+        }
+        console.log(`ProseMeteor AuthorityRegistry: Reset the failed health checks count for ${successfullChecksThatFailedPreviously.length} servers: ${successfullChecksThatFailedPreviously}`);
       });
     }
   }

--- a/lib/imports/api/authority-registry/server/authority-registry.js
+++ b/lib/imports/api/authority-registry/server/authority-registry.js
@@ -3,7 +3,8 @@ import {
   removeAuthority,
   storeFailedHealthChecks,
   removeAuthorities,
-  resetFailedHealthChecksCount
+  resetFailedHealthChecksCount,
+  addDocToAuthority
 } from './methods';
 import { authorityRegistryColl } from './collection';
 import { WebApp } from 'meteor/webapp';
@@ -26,9 +27,9 @@ export class AuthorityRegistry {
     this.ip = ip.address();
     this.port = parseInt(process.env.PORT);
 
-    const fullUrl = `${this.ip}:${this.port}`;
-    this.fullUrlWithProtocol = (this.port === HTTPS_PORT) ? `https://${fullUrl}` : `http://${fullUrl}`;
-    console.log(`ProseMeteor AuthorityRegistry, this server url: ${this.fullUrlWithProtocol}`);
+    const ipAndPort = `${this.ip}:${this.port}`;
+    this.fullUrl = (this.port === HTTPS_PORT) ? `https://${ipAndPort}` : `http://${ipAndPort}`;
+    console.log(`ProseMeteor AuthorityRegistry, this server url: ${this.ipAndPort}`);
 
     // bind class methods
     this.setUpHealthCheckEndpoint = this.setUpHealthCheckEndpoint.bind(this);
@@ -39,7 +40,7 @@ export class AuthorityRegistry {
     this.runHealthChecks = this.runHealthChecks.bind(this);
     this.fullRegistry = this.fullRegistry.bind(this);
     this.isRegistered = this.isRegistered.bind(this);
-    this.getUrlOfAuthorityHostingDoc = this.getUrlOfAuthorityHostingDoc.bind(this);
+    this.getEligibleAuthoritiesToHostDoc = this.getEligibleAuthoritiesToHostDoc.bind(this);
     this.chooseAuthorityToHostDoc = this.chooseAuthorityToHostDoc.bind(this);
 
     this.setUpHealthCheckEndpoint();
@@ -64,15 +65,8 @@ export class AuthorityRegistry {
   * Creates Meteor Methods to allow clients to communicate with the AuthorityRegistry.
   */
   setupClientMethods () {
-    let self = this;
-    Meteor.methods({
-      // allow clients to request latest doc state
-      'ProseMeteor.getUrlOfAuthorityHostingDoc' ({ docId, groupId }) {
-        check(docId, String);
-        check(groupId, Match.Maybe(String));
-        return self.getUrlOfAuthorityHostingDoc({ docId, groupId });
-      }
-    });
+    // let self = this;
+    // Meteor.methods({});
   }
   /**
   *  Starts a continuous interval to run health checks against all other servers so
@@ -143,7 +137,7 @@ export class AuthorityRegistry {
   * @param {Function} cb                  callback, given Boolean of if health check passed
   */
   runSingleHealthCheck ({ authorityUrl }, cb) {
-    const authority = this.getAuthority({ authorityUrl });
+    const authority = this.getAuthorityInfoByUrl({ authorityUrl });
     // run health check. if number of failed === 0, it was healthy
     const numFailed = this.runHealthChecks([ authority ]);
     const passed = numFailed === 0;
@@ -242,13 +236,33 @@ export class AuthorityRegistry {
   }
 
   /**
-  *  Returns a single authority from the registry database.
+  *  Returns a single authority from the registry database, found via its url.
   * @param {Object} params
   * @param {String} params.authorityUrl     full url of the authority to find (protocol:ip:port)
   * @returns {{}} authority
   */
-  getAuthority ({ authorityUrl }) {
+  getAuthorityInfoByUrl ({ authorityUrl }) {
     return authorityRegistryColl.findOne({ fullUrl: authorityUrl });
+  }
+
+  /**
+  *  Returns a single authority from the registry database, found via a docId that lives in an authority.
+  * @param {Object} params
+  * @param {String} params.docId        id of the doc that the wanted authority is hosting
+  * @returns {{}} authority
+  */
+  getAuthorityInfoByDocId ({ docId }) {
+    return authorityRegistryColl.findOne({ docIds: docId });
+  }
+
+  /**
+  *  Returns a single authority from the registry database, found via a groupId that lives in an authority.
+  * @param {Object} params
+  * @param {String} params.groupId        groupId that the wanted authority is hosting
+  * @returns {{}} authority
+  */
+  getAuthorityInfoByGroupId ({ groupId }) {
+    return authorityRegistryColl.findOne({ groupId: groupId });
   }
   /**
   *  Returns if the specified server is registered or not.
@@ -262,79 +276,80 @@ export class AuthorityRegistry {
     check(port, Number);
     return authorityRegistryColl.find({ ip, port }).count() !== 0;
   }
-  addDocToAuthority ({ ip, docId }) {
-    // delegate the doc to the specified authority
+
+  /**
+  *  Adds a doc to an authority in the registry.
+  * @param {Object} params
+  * @param {String} params.docId      unique id for this doc
+  * @param {String} [params.groupId]  optional, a groupId of this doc to associate it with other docs
+  */
+  addDocToAuthority ({ docId, groupId = null }) {
+    addDocToAuthority.call({ docId, groupId, fullUrl: this.fullUrl });
+    console.log(`ProseMeteor AuthorityRegistry: Added doc ${docId} to authority ${this.fullUrl}. Updated registry: ${JSON.stringify(this.fullRegistry(), null, 2)}`);
   }
-  removeDocFromAuthority ({ docId }) {
-    // remove a doc from its authority
+  /**
+  *  Removes a doc from an authority in the registry. If this doc is in a groupId and no more of that group are hosted
+  *  on this server, the groupId is also removed from this authority.
+  * @param {Object} params
+  * @param {String} params.docId      unique id for this doc
+  * @param {String} [params.groupId]  optional, a groupId of this doc to associate it with other docs
+  */
+  removeDocFromAuthority ({ docId, groupId = null }) {
+    // first remove this docId
+
+    if (groupId) {
+      // check each remaining docId. if any have the same groupId, keep this docs groupId. otherwise remove it from groupIds[]
+    }
   }
   /**
   *  Returns the full url of the authority that does/will host this doc.
   * @param {Object} params
   * @param {String} params.docId      unique id for this doc
   * @param {String} [params.groupId]  optional, a groupId of this doc to associate it with other docs
-  * @returns {String} url of authority that does/will host this doc
+  * @returns {Array} eligibleAuthorities  array of eligible authorities
   */
-  getUrlOfAuthorityHostingDoc ({ docId, groupId }) {
+  getEligibleAuthoritiesToHostDoc ({ docId, groupId = null }) {
     check(docId, String);
     check(groupId, Match.Maybe(String));
     console.log(`ProseMeteor AuthorityRegistry: searching for url of authority hosting docId "${docId}", groupId "${groupId || 'none'}"`);
     // return ip of authority, or undefined
-    const authority = authorityRegistryColl.findOne({ docIds: docId });
-    let port, ip;
+    const authority = this.getAuthorityInfoByDocId({ docId });
     if (authority) {
       console.log(`ProseMeteor AuthorityRegistry: Found an authority hosting docId "${docId}", selecting it "${docId}"`);
-      ip = authority.ip;
-      port = authority.port;
+      return [authority];
     } else {
-      let chosenAuthority = this.chooseAuthorityToHostDoc({ docId, groupId });
-      ip = chosenAuthority.ip;
-      port = chosenAuthority.port;
+      let chosenAuthorities = this.chooseAuthorityToHostDoc({ docId, groupId });
+      return chosenAuthorities;
     }
-    const fullUrl = `${ip}:${port}`;
-    const fullUrlWithProtocol = (port === HTTPS_PORT) ? `https://${fullUrl}` : `http://${fullUrl}`;
-    return fullUrlWithProtocol;
   }
   /**
   *  Chooses an authority to host a document.
   * @param {Object} params
   * @param {String} params.docId      unique id for this doc
   * @param {String} [params.groupId]  optional, a groupId of this doc to associate it with other docs
-  * @returns {Object} { ip: {String}, port: {Number} }
+  * @returns {Array}  chosenAuthorities     array of chosen authority servers. can be length one if a
+  *                                         server MUST host this doc, otherwise length is > 1 in case first choices fail
   */
-  chooseAuthorityToHostDoc ({ docId, groupId }) {
+  chooseAuthorityToHostDoc ({ docId, groupId = null }) {
     check(docId, String);
     check(groupId, Match.Maybe(String));
     // if there is already a server hosting this groupId, use it so they all are hosted together
     if (groupId) {
-      const authorityHostingGroup = authorityRegistryColl.findOne({ groupIds: groupId });
+      const authorityHostingGroup = this.getAuthorityInfoByGroupId({ groupId });
       if (authorityHostingGroup) {
         console.log(`ProseMeteor AuthorityRegistry: Found an authority hosting groupId "${groupId}", selecting it to host docId "${docId}"`);
-        return {
-          ip: authorityHostingGroup.ip,
-          port: authorityHostingGroup.port
-        };
+        return [authorityHostingGroup];
       }
     }
-    // otherwise choose the server currently hosting the lowest number of docs
+    // otherwise get 1-5 servers hosting the lowest number of docs
     const fullRegistry = this.fullRegistry();
-    let indexOfLowestDocIds;
-    let lowestDocIdsCount;
-    fullRegistry.forEach(({ _id, ip, port, docIds }, index) => {
-      if (typeof lowestDocIdsCount === 'undefined') {
-        lowestDocIdsCount = docIds.length;
-        indexOfLowestDocIds = index;
-      } else if (docIds.length < lowestDocIdsCount) {
-        lowestDocIdsCount = docIds.length;
-        indexOfLowestDocIds = index;
-      }
-    });
-    const authorityWithLeastDocs = fullRegistry[indexOfLowestDocIds];
-    console.log(`ProseMeteor AuthorityRegistry: Selecting authority server with least documents: "${authorityWithLeastDocs.ip}:${authorityWithLeastDocs.port}" (${lowestDocIdsCount} docs)`);
+    const fullRegistrySortedByDocIdsCount = fullRegistry
+      .sort((authorityA, authorityB) => {
+        return authorityA.docIds.length > authorityB.docIds.lenth;
+      })
+      .slice(0, 5);
+    console.log(`ProseMeteor AuthorityRegistry: Selecting authority servers with least documents in order: "${JSON.stringify(fullRegistrySortedByDocIdsCount, null, 2)}"`);
 
-    return {
-      ip: authorityWithLeastDocs.ip,
-      port: authorityWithLeastDocs.port
-    };
+    return fullRegistrySortedByDocIdsCount;
   }
 }

--- a/lib/imports/api/authority-registry/server/authority-registry.js
+++ b/lib/imports/api/authority-registry/server/authority-registry.js
@@ -1,31 +1,50 @@
 import { insertAuthority, removeAuthority } from './methods';
+import { authorityRegistryColl } from './collection';
 
 export class AuthorityRegistry {
   register ({ ip, port }, cb) {
-    insertAuthority.call({ authorityIp: ip, port }, (err, res) => {
-      if (err) {
-        return cb(new Error(`Failed to insert Authority into registry: ${err}`));
-      }
-      return cb(null, res);
-    });
+    const insert = () => {
+      insertAuthority.call({ ip, port }, (err, res) => {
+        if (err) {
+          return cb(new Error(`Failed to insert Authority server into registry: ${err}`));
+        }
+        return cb(null, res);
+      });
+    };
+
+    if (this.isRegistered({ ip })) {
+      console.log(`Authority server is already registered, clearing it out`);
+      removeAuthority.call({ ip }, (err, res) => {
+        if (err) {
+          return cb(new Error(`Failed to remove existing authority server ${err}`));
+        }
+        return insert();
+      });
+    } else {
+      return insert();
+    }
   }
   unregister ({ ip }, cb) {
     // remove from collection
-    removeAuthority.call({ authorityIp: ip }, (err, res) => {
+    removeAuthority.call({ ip }, (err, res) => {
       if (err) {
-        return cb(new Error(`Failed to remove Authority from registry: ${err}`));
+        return cb(new Error(`Failed to remove Authority server from registry: ${err}`));
       }
-      console.log(`Unregistered authority with ip ${ip}`);
+      console.log(`Unregistered authority server with ip ${ip}`);
       return cb(null, res);
     });
   }
-  addDocToAuthority ({ authorityIp, docId }) {
+  isRegistered ({ ip }) {
+    return authorityRegistryColl.find({ ip }).count() !== 0;
+  }
+
+  addDocToAuthority ({ ip, docId }) {
     // delegate the doc to the specified authority
   }
   removeDocFromAuthority ({ docId }) {
     // remove a doc from its authority
   }
-  getAuthorityIpHostingDoc ({ docId }) {
+  getipHostingDoc ({ docId }) {
     // return ip of authority, or undefined
   }
   chooseAuthorityToHostDoc ({ docId }) {

--- a/lib/imports/api/authority-registry/server/authority-registry.js
+++ b/lib/imports/api/authority-registry/server/authority-registry.js
@@ -1,23 +1,21 @@
-import ip from 'ip';
 import { insertAuthority, removeAuthority } from './methods';
 
 export class AuthorityRegistry {
-  registerAuthority(cb) {
-    const authorityIp = ip.address();
-    insertAuthority.call({ authorityIp }, (err, res) => {
+  register({ ip, port }, cb) {
+    insertAuthority.call({ authorityIp: ip }, (err, res) => {
       if (err) {
-        return cb(new Error('Failed to insert Authority into registry :' + err));
+        return cb(new Error(`Failed to insert Authority into registry: ${err}`));
       }
       return cb(null, res);
     });
   }
-  unregisterAuthority(cb) {
+  unregister({ ip, port }, cb) {
     // remove from collection
-    const authorityIp = ip.address();
-    removeAuthority.call({ authorityIp }, (err, res) => {
+    removeAuthority.call({ authorityIp: ip }, (err, res) => {
       if (err) {
-        return cb(new Error('Failed to remove Authority from registry :' + err));
+        return cb(new Error(`Failed to remove Authority from registry: ${err}`));
       }
+      console.log(`Unregistered authority with ip ${ip}:${port}`);
       return cb(null, res);
     });
   }

--- a/lib/imports/api/authority-registry/server/authority-registry.js
+++ b/lib/imports/api/authority-registry/server/authority-registry.js
@@ -9,13 +9,13 @@ export class AuthorityRegistry {
       return cb(null, res);
     });
   }
-  unregister ({ ip, port }, cb) {
+  unregister ({ ip }, cb) {
     // remove from collection
     removeAuthority.call({ authorityIp: ip }, (err, res) => {
       if (err) {
         return cb(new Error(`Failed to remove Authority from registry: ${err}`));
       }
-      console.log(`Unregistered authority with ip ${ip}:${port}`);
+      console.log(`Unregistered authority with ip ${ip}`);
       return cb(null, res);
     });
   }

--- a/lib/imports/api/authority-registry/server/authority-registry.js
+++ b/lib/imports/api/authority-registry/server/authority-registry.js
@@ -8,7 +8,7 @@ import {
 import { authorityRegistryColl } from './collection';
 import { WebApp } from 'meteor/webapp';
 import { HTTP } from 'meteor/http';
-import { check } from 'meteor/check';
+import { check, Match } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import ip from 'ip';
 
@@ -23,7 +23,11 @@ export class AuthorityRegistry {
     this.port = parseInt(process.env.PORT);
     this.setUpHealthCheckEndpoint();
     this.startHealthCheckInterval();
+    this.setupClientMethods();
   }
+  /**
+  * Creates a health check endpoint for this server
+  */
   setUpHealthCheckEndpoint () {
     // create a health check endpoint, so other servers can verify this server is alive or not
     WebApp.rawConnectHandlers.use('/prosemeteor-health-check', (req, res, next) => {
@@ -34,11 +38,35 @@ export class AuthorityRegistry {
       next();
     });
   }
+
+  /**
+  * Creates Meteor Methods to allow clients to communicate with the AuthorityRegistry.
+  */
+  setupClientMethods () {
+    let self = this;
+    Meteor.methods({
+      // allow clients to request latest doc state
+      'ProseMeteor.getUrlOfAuthorityHostingDoc' ({ docId, groupId }) {
+        check(docId, String);
+        check(groupId, Match.Maybe(String));
+        return self.getUrlOfAuthorityHostingDoc({ docId, groupId });
+      }
+    });
+  }
+  /**
+  *  Starts a continuous interval to run health checks against all other servers so
+  *  we can know when an authority server is no longer available.
+  */
   startHealthCheckInterval () {
     Meteor.setInterval(() => {
       this.runHealthChecks();
     }, HEALTH_CHECK_INTERVAL_MS);
   }
+  /**
+  *  Register this app server as an authority server that is ready to host document authorities, storing
+  *  it in the registry.
+  * @param {Function} cb        callback
+  */
   register (cb) {
     check(cb, Function);
     const insert = () => {
@@ -66,6 +94,13 @@ export class AuthorityRegistry {
       return insert();
     }
   }
+  /**
+  *  Remove an app server from the registry, because it's no longer available to host document authorities.
+  * @param {Object} params
+  * @param {String} params.ip     ip of the server to remove from the registry
+  * @param {Number} params.port   port of the server to remove from the registry
+  * @param {Function} cb          callback
+  */
   unregister ({ ip, port }, cb) {
     check(ip, String);
     check(port, Number);
@@ -79,6 +114,10 @@ export class AuthorityRegistry {
       return cb(null, res);
     });
   }
+  /**
+  *  Run health checks against every server in the registry, keeping track of which have failed
+  * and removing those that have failed more than the threshold.
+  */
   runHealthChecks () {
     const fullRegistry = this.fullRegistry();
     const numServers = fullRegistry.length;
@@ -151,9 +190,20 @@ export class AuthorityRegistry {
       });
     }
   }
+  /**
+  *  Returns the full authority registry from the database.
+  * @returns {Array} full registry
+  */
   fullRegistry () {
     return authorityRegistryColl.find({}).fetch();
   }
+  /**
+  *  Returns if the specified server is registered or not.
+  * @param {Object} params
+  * @param {String} params.ip     ip of the server to remove from the registry
+  * @param {Number} params.port   port of the server to remove from the registry
+  * @returns {Boolean} if the server is registered
+  */
   isRegistered ({ ip, port }) {
     check(ip, String);
     check(port, Number);
@@ -165,12 +215,22 @@ export class AuthorityRegistry {
   removeDocFromAuthority ({ docId }) {
     // remove a doc from its authority
   }
+  /**
+  *  Returns the full url of the authority that does/will host this doc.
+  * @param {Object} params
+  * @param {String} params.docId      unique id for this doc
+  * @param {String} [params.groupId]  optional, a groupId of this doc to associate it with other docs
+  * @returns {String} url of authority that does/will host this doc
+  */
   getUrlOfAuthorityHostingDoc ({ docId, groupId }) {
     check(docId, String);
+    check(groupId, Match.Maybe(String));
+    console.log(`ProseMeteor AuthorityRegistry: searching for url of authority hosting docId "${docId}", groupId "${groupId || 'none'}"`);
     // return ip of authority, or undefined
     const authority = authorityRegistryColl.findOne({ docIds: docId });
     let port, ip;
     if (authority) {
+      console.log(`ProseMeteor AuthorityRegistry: Found an authority hosting docId "${docId}", selecting it "${docId}"`);
       ip = authority.ip;
       port = authority.port;
     } else {
@@ -182,13 +242,21 @@ export class AuthorityRegistry {
     const fullUrlWithProtocol = (port === HTTPS_PORT) ? `https://${fullUrl}` : `http://${fullUrl}`;
     return fullUrlWithProtocol;
   }
+  /**
+  *  Chooses an authority to host a document.
+  * @param {Object} params
+  * @param {String} params.docId      unique id for this doc
+  * @param {String} [params.groupId]  optional, a groupId of this doc to associate it with other docs
+  * @returns {Object} { ip: {String}, port: {Number} }
+  */
   chooseAuthorityToHostDoc ({ docId, groupId }) {
     check(docId, String);
+    check(groupId, Match.Maybe(String));
     // if there is already a server hosting this groupId, use it so they all are hosted together
     if (groupId) {
-      check(groupId, String);
       const authorityHostingGroup = authorityRegistryColl.findOne({ groupIds: groupId });
       if (authorityHostingGroup) {
+        console.log(`ProseMeteor AuthorityRegistry: Found an authority hosting groupId "${groupId}", selecting it to host docId "${docId}"`);
         return {
           ip: authorityHostingGroup.ip,
           port: authorityHostingGroup.port
@@ -209,6 +277,8 @@ export class AuthorityRegistry {
       }
     });
     const authorityWithLeastDocs = fullRegistry[indexOfLowestDocIds];
+    console.log(`ProseMeteor AuthorityRegistry: Selecting authority server with least documents: "${authorityWithLeastDocs.ip}:${authorityWithLeastDocs.port}" (${lowestDocIdsCount} docs)`);
+
     return {
       ip: authorityWithLeastDocs.ip,
       port: authorityWithLeastDocs.port

--- a/lib/imports/api/authority-registry/server/authority-registry.js
+++ b/lib/imports/api/authority-registry/server/authority-registry.js
@@ -1,12 +1,25 @@
-// import ip from 'ip';
+import ip from 'ip';
+import { insertAuthority, removeAuthority } from './methods';
 
 export class AuthorityRegistry {
-  registerAuthority() {
-    // let authorityIp = ip.address();
-    // insert { authorityIp, docIds: [] } into collection
+  registerAuthority(cb) {
+    const authorityIp = ip.address();
+    insertAuthority.call({ authorityIp }, (err, res) => {
+      if (err) {
+        return cb(new Error('Failed to insert Authority into registry :' + err));
+      }
+      return cb(null, res);
+    });
   }
-  unregisterAuthority({ authorityIp }) {
+  unregisterAuthority(cb) {
     // remove from collection
+    const authorityIp = ip.address();
+    removeAuthority.call({ authorityIp }, (err, res) => {
+      if (err) {
+        return cb(new Error('Failed to remove Authority from registry :' + err));
+      }
+      return cb(null, res);
+    });
   }
   addDocToAuthority({ authorityIp, docId }) {
     // delegate the doc to the specified authority

--- a/lib/imports/api/authority-registry/server/authority-registry.js
+++ b/lib/imports/api/authority-registry/server/authority-registry.js
@@ -1,17 +1,34 @@
 import { insertAuthority, removeAuthority } from './methods';
 import { authorityRegistryColl } from './collection';
+import { WebApp } from 'meteor/webapp';
+import { HTTP } from 'meteor/http';
 
 export class AuthorityRegistry {
+  constructor () {
+    // create a health check endpoint, so other servers can verify this server is alive or not
+    WebApp.rawConnectHandlers.use(`/prosemeteor-health-check`, (req, res, next) => {
+      console.log(`--req:`, req);
+      console.log(`--res:`, res);
+      res.writeHead(200, {
+        'Content-Type': `text/plain`
+      });
+      res.end(`ProseMeteor Health OK`);
+      next();
+    });
+  }
   register ({ ip, port }, cb) {
     const insert = () => {
+      // insert the server
       insertAuthority.call({ ip, port }, (err, res) => {
         if (err) {
           return cb(new Error(`Failed to insert Authority server into registry: ${err}`));
         }
         return cb(null, res);
       });
+      // at the same time, start the health checks on all other servers
+      this.runHealthChecks();
     };
-
+    // check if this sever's already registered first
     if (this.isRegistered({ ip, port })) {
       console.log(`Authority server is already registered, clearing it out`);
       removeAuthority.call({ ip }, (err, res) => {
@@ -24,6 +41,42 @@ export class AuthorityRegistry {
       return insert();
     }
   }
+
+  runHealthChecks () {
+    const fullRegistry = this.fullRegistry();
+    const numServers = fullRegistry.length;
+    console.log(`---starting health checks for ${numServers} servers`);
+    // let numServerChecked = 0;
+    fullRegistry.forEach(({ ip, port }) => {
+      const healthCheckUrl = `${ip}:${port}/prosemeteor-health-check`;
+      const httpUrl = `http://${healthCheckUrl}`;
+      const httpsUrl = `https://${healthCheckUrl}`;
+      let httpRes;
+      let httpsRes;
+      try {
+        httpRes = HTTP.get(httpUrl);
+      } catch (e) {
+        console.log(`httpRes failed ${e}`);
+      }
+      try {
+        httpsRes = HTTP.get(httpsUrl);
+      } catch (e) {
+        console.log(`httpsRes failed ${e}`);
+      }
+      if (httpRes) {
+        console.log(`---http res: ${httpRes}`);
+      }
+      if (httpsRes) {
+        console.log(`---https res: ${httpsRes}`);
+      }
+      // const res = HTTP.get(healthCheckUrl, (err, res) => {
+      //   console.log(`--------${healthCheckUrl}`);
+      //   console.log(`--err: ${err}`);
+      //   console.log(`--res ${res}`);
+      // });
+    });
+    console.log(`---finished health checks`);
+  }
   unregister ({ ip, port }, cb) {
     // remove from collection
     removeAuthority.call({ ip, port }, (err, res) => {
@@ -33,6 +86,10 @@ export class AuthorityRegistry {
       console.log(`Unregistered authority server with ip ${ip}`);
       return cb(null, res);
     });
+  }
+
+  fullRegistry () {
+    return authorityRegistryColl.find({}).fetch();
   }
 
   isRegistered ({ ip, port }) {

--- a/lib/imports/api/authority-registry/server/authority-registry.js
+++ b/lib/imports/api/authority-registry/server/authority-registry.js
@@ -8,6 +8,7 @@ import {
 import { authorityRegistryColl } from './collection';
 import { WebApp } from 'meteor/webapp';
 import { HTTP } from 'meteor/http';
+import { check } from 'meteor/check';
 
 export class AuthorityRegistry {
   constructor () {
@@ -22,6 +23,9 @@ export class AuthorityRegistry {
     });
   }
   register ({ ip, port }, cb) {
+    check(ip, String);
+    check(port, Number);
+    check(cb, Function);
     const insert = () => {
       // insert the server
       insertAuthority.call({ ip, port }, (err, res) => {
@@ -48,6 +52,9 @@ export class AuthorityRegistry {
     }
   }
   unregister ({ ip, port }, cb) {
+    check(ip, String);
+    check(port, Number);
+    check(cb, Function);
     // remove from collection
     removeAuthority.call({ ip, port }, (err, res) => {
       if (err) {
@@ -58,6 +65,8 @@ export class AuthorityRegistry {
     });
   }
   runHealthChecks ({ thisServerIp, thisServerPort }) {
+    check(thisServerIp, String);
+    check(thisServerPort, Number);
     const fullRegistry = this.fullRegistry();
     const numServers = fullRegistry.length;
     let failedConnections = [];                       // _ids of all servers that failed checks, that didn't pass the threshold
@@ -101,6 +110,7 @@ export class AuthorityRegistry {
       if (httpFailed && httpsFailed) {
         failedConnections.push(_id);
       } else {
+        console.log(`ProseMeteor AuthorityRegistry: Server passed healt check: ${ip}:${port}`);
         // if this server failed a previous health check but passed this time, mark it to reset its failedHealthChecks count
         if (failedConnections > 0) {
           successfullChecksThatFailedPreviously.push(_id);
@@ -140,6 +150,8 @@ export class AuthorityRegistry {
     return authorityRegistryColl.find({}).fetch();
   }
   isRegistered ({ ip, port }) {
+    check(ip, String);
+    check(port, Number);
     return authorityRegistryColl.find({ ip, port }).count() !== 0;
   }
   addDocToAuthority ({ ip, docId }) {

--- a/lib/imports/api/authority-registry/server/authority-registry.js
+++ b/lib/imports/api/authority-registry/server/authority-registry.js
@@ -30,12 +30,12 @@ export class AuthorityRegistry {
   */
   setUpHealthCheckEndpoint () {
     // create a health check endpoint, so other servers can verify this server is alive or not
-    WebApp.rawConnectHandlers.use('/prosemeteor-health-check', (req, res, next) => {
+    WebApp.rawConnectHandlers.use('/prosemeteor-health-check', (req, res, cb) => {
       res.writeHead(200, {
         'Content-Type': 'text/plain'
       });
       res.end(HEALTH_CHECK_RESPONSE);
-      next();
+      cb();
     });
   }
 

--- a/lib/imports/api/authority-registry/server/authority-registry.js
+++ b/lib/imports/api/authority-registry/server/authority-registry.js
@@ -9,21 +9,35 @@ import { authorityRegistryColl } from './collection';
 import { WebApp } from 'meteor/webapp';
 import { HTTP } from 'meteor/http';
 import { check } from 'meteor/check';
+import { Meteor } from 'meteor/meteor';
 import ip from 'ip';
+
+const HTTPS_PORT = 443;
+const HEALTH_CHECK_RESPONSE = 'ProseMeteor Health OK';
+const FAILED_HEALTH_CHECKS_THRESHOLD = 5;
+const HEALTH_CHECK_INTERVAL_MS = 1000 * 10;   // interval on which to run health checks
 
 export class AuthorityRegistry {
   constructor () {
     this.ip = ip.address();
     this.port = parseInt(process.env.PORT);
-    this.failedHealthChecksThreshold = 3;
+    this.setUpHealthCheckEndpoint();
+    this.startHealthCheckInterval();
+  }
+  setUpHealthCheckEndpoint () {
     // create a health check endpoint, so other servers can verify this server is alive or not
-    WebApp.rawConnectHandlers.use(`/prosemeteor-health-check`, (req, res, next) => {
+    WebApp.rawConnectHandlers.use('/prosemeteor-health-check', (req, res, next) => {
       res.writeHead(200, {
-        'Content-Type': `text/plain`
+        'Content-Type': 'text/plain'
       });
-      res.end(`ProseMeteor Health OK`);
+      res.end(HEALTH_CHECK_RESPONSE);
       next();
     });
+  }
+  startHealthCheckInterval () {
+    Meteor.setInterval(() => {
+      this.runHealthChecks();
+    }, HEALTH_CHECK_INTERVAL_MS);
   }
   register (cb) {
     check(cb, Function);
@@ -41,7 +55,7 @@ export class AuthorityRegistry {
     };
     // check if this sever's already registered first
     if (this.isRegistered({ ip: this.ip, port: this.port })) {
-      console.log(`ProseMeteor AuthorityRegistry: Authority server was already registered, clearing it out`);
+      console.log('ProseMeteor AuthorityRegistry: Authority server was already registered, clearing it out');
       removeAuthority.call({ ip: this.ip }, (err, res) => {
         if (err) {
           return cb(new Error(`Failed to remove existing authority server ${err}`));
@@ -53,6 +67,8 @@ export class AuthorityRegistry {
     }
   }
   unregister ({ ip, port }, cb) {
+    check(ip, String);
+    check(port, Number);
     check(cb, Function);
     // remove from collection
     removeAuthority.call({ ip, port }, (err, res) => {
@@ -69,47 +85,39 @@ export class AuthorityRegistry {
     let failedConnections = [];                       // _ids of all servers that failed checks, that didn't pass the threshold
     let failedConnectionsAboveThreshold = [];         // _ids of all servers that failed checks, that did pass the threshold
     let successfullChecksThatFailedPreviously = [];   // _ids of all servers that had a previous failure but passed this time, without passing the threshold
-    console.log(`ProseMeteor AuthorityRegistry: Starting health checks for ${numServers} servers`);
+    console.log(`ProseMeteor AuthorityRegistry: Starting health checks for ${numServers} servers at time: ${new Date()}`);
+    console.log(`Full registry: ${JSON.stringify(fullRegistry, null, 2)}`);
     // do a check on each server
     fullRegistry.forEach(({ _id, ip, port, failedHealthChecks }) => {
       if (ip === this.ip && port === this.port) {
-        console.log(`ProseMeteor AuthorityRegistry: Skipping this server's health check`);
+        console.log('ProseMeteor AuthorityRegistry: Skipping this server\'s health check');
         return;
       }
       // if this server has failed too many times, remove it from the registry since we can assume it's down
-      if (failedHealthChecks >= this.failedHealthChecksThreshold) {
+      if (failedHealthChecks >= FAILED_HEALTH_CHECKS_THRESHOLD) {
         console.log(`ProseMeteor AuthorityRegistry: ${ip}:${port} has failed ${failedHealthChecks} consecutive health checks, marking it to be removed from the registry`);
         failedConnectionsAboveThreshold.push(_id);
         return;
       }
       const healthCheckUrl = `${ip}:${port}/prosemeteor-health-check`;
-      const httpUrl = `http://${healthCheckUrl}`;
-      const httpsUrl = `https://${healthCheckUrl}`;
-      let httpRes, httpsRes;
-      let httpFailed = false;
-      let httpsFailed = false;
+      // use http or https depending on port
+      const healthCheckUrlWithProtocol = (port === HTTPS_PORT) ? `https://${healthCheckUrl}` : `http://${healthCheckUrl}`;
+      let healthCheckRes;
+      let healthCheckFailed = false;
       try {
-        httpRes = HTTP.get(httpUrl);
-        if (httpRes !== `ProseMeteor Health OK`) {
-          httpFailed = true;
+        healthCheckRes = HTTP.get(healthCheckUrlWithProtocol);
+        if (healthCheckRes !== HEALTH_CHECK_RESPONSE) {
+          healthCheckFailed = true;
         }
       } catch (e) {
-        httpFailed = true;
+        healthCheckFailed = true;
       }
-      try {
-        httpsRes = HTTP.get(httpsUrl);
-        if (httpsRes !== `ProseMeteor Health OK`) {
-          httpsFailed = true;
-        }
-      } catch (e) {
-        httpsFailed = true;
-      }
-      if (httpFailed && httpsFailed) {
+      if (healthCheckFailed) {
         failedConnections.push(_id);
       } else {
-        console.log(`ProseMeteor AuthorityRegistry: Server passed healt check: ${ip}:${port}`);
+        console.log(`ProseMeteor AuthorityRegistry: Server passed health check: ${ip}:${port}`);
         // if this server failed a previous health check but passed this time, mark it to reset its failedHealthChecks count
-        if (failedConnections > 0) {
+        if (failedHealthChecks > 0) {
           successfullChecksThatFailedPreviously.push(_id);
         }
       }
@@ -121,7 +129,7 @@ export class AuthorityRegistry {
         if (err) {
           console.log(`ProseMeteor AuthorityRegistry: Failed to store failed health checks: ${err}`);
         }
-        console.log(`ProseMeteor AuthorityRegistry: Successfully stored failed health checks`);
+        console.log('ProseMeteor AuthorityRegistry: Successfully stored failed health checks');
       });
     }
     // remove servers that have failed too many health checks
@@ -157,12 +165,53 @@ export class AuthorityRegistry {
   removeDocFromAuthority ({ docId }) {
     // remove a doc from its authority
   }
-  getipHostingDoc ({ docId }) {
+  getUrlOfAuthorityHostingDoc ({ docId, groupId }) {
+    check(docId, String);
     // return ip of authority, or undefined
+    const authority = authorityRegistryColl.findOne({ docIds: docId });
+    let port, ip;
+    if (authority) {
+      ip = authority.ip;
+      port = authority.port;
+    } else {
+      let chosenAuthority = this.chooseAuthorityToHostDoc({ docId, groupId });
+      ip = chosenAuthority.ip;
+      port = chosenAuthority.port;
+    }
+    const fullUrl = `${ip}:${port}`;
+    const fullUrlWithProtocol = (port === HTTPS_PORT) ? `https://${fullUrl}` : `http://${fullUrl}`;
+    return fullUrlWithProtocol;
   }
-  chooseAuthorityToHostDoc ({ docId }) {
-    // -queries collection for all authorities
-    // -gets ip of last selected authority from db
-    // -iterate over authorities in sorted order. choose the one AFTER the last one selected
+  chooseAuthorityToHostDoc ({ docId, groupId }) {
+    check(docId, String);
+    // if there is already a server hosting this groupId, use it so they all are hosted together
+    if (groupId) {
+      check(groupId, String);
+      const authorityHostingGroup = authorityRegistryColl.findOne({ groupIds: groupId });
+      if (authorityHostingGroup) {
+        return {
+          ip: authorityHostingGroup.ip,
+          port: authorityHostingGroup.port
+        };
+      }
+    }
+    // otherwise choose the server currently hosting the lowest number of docs
+    const fullRegistry = this.fullRegistry();
+    let indexOfLowestDocIds;
+    let lowestDocIdsCount;
+    fullRegistry.forEach(({ _id, ip, port, docIds }, index) => {
+      if (typeof lowestDocIdsCount === 'undefined') {
+        lowestDocIdsCount = docIds.length;
+        indexOfLowestDocIds = index;
+      } else if (docIds.length < lowestDocIdsCount) {
+        lowestDocIdsCount = docIds.length;
+        indexOfLowestDocIds = index;
+      }
+    });
+    const authorityWithLeastDocs = fullRegistry[indexOfLowestDocIds];
+    return {
+      ip: authorityWithLeastDocs.ip,
+      port: authorityWithLeastDocs.port
+    };
   }
 }

--- a/lib/imports/api/authority-registry/server/authority-registry.js
+++ b/lib/imports/api/authority-registry/server/authority-registry.js
@@ -9,7 +9,7 @@ import {
 import { authorityRegistryColl } from './collection';
 import { WebApp } from 'meteor/webapp';
 import { HTTP } from 'meteor/http';
-import { check, Match } from 'meteor/check';
+import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import ip from 'ip';
 
@@ -41,7 +41,6 @@ export class AuthorityRegistry {
     this.fullRegistry = this.fullRegistry.bind(this);
     this.isRegistered = this.isRegistered.bind(this);
     this.getEligibleAuthoritiesToHostDoc = this.getEligibleAuthoritiesToHostDoc.bind(this);
-    this.chooseAuthorityToHostDoc = this.chooseAuthorityToHostDoc.bind(this);
 
     this.setUpHealthCheckEndpoint();
     this.startHealthCheckInterval();
@@ -302,45 +301,10 @@ export class AuthorityRegistry {
     }
   }
   /**
-  *  Returns the full url of the authority that does/will host this doc.
-  * @param {Object} params
-  * @param {String} params.docId      unique id for this doc
-  * @param {String} [params.groupId]  optional, a groupId of this doc to associate it with other docs
-  * @returns {Array} eligibleAuthorities  array of eligible authorities
+  *  Chooses a list of eligible authority servers to host a document, preferring the server with the least documents.
+  * @returns {Array}  chosenAuthorities     array of chosen authority servers
   */
-  getEligibleAuthoritiesToHostDoc ({ docId, groupId = null }) {
-    check(docId, String);
-    check(groupId, Match.Maybe(String));
-    console.log(`ProseMeteor AuthorityRegistry: searching for url of authority hosting docId "${docId}", groupId "${groupId || 'none'}"`);
-    // return ip of authority, or undefined
-    const authority = this.getAuthorityInfoByDocId({ docId });
-    if (authority) {
-      console.log(`ProseMeteor AuthorityRegistry: Found an authority hosting docId "${docId}", selecting it "${docId}"`);
-      return [authority];
-    } else {
-      let chosenAuthorities = this.chooseAuthorityToHostDoc({ docId, groupId });
-      return chosenAuthorities;
-    }
-  }
-  /**
-  *  Chooses an authority to host a document.
-  * @param {Object} params
-  * @param {String} params.docId      unique id for this doc
-  * @param {String} [params.groupId]  optional, a groupId of this doc to associate it with other docs
-  * @returns {Array}  chosenAuthorities     array of chosen authority servers. can be length one if a
-  *                                         server MUST host this doc, otherwise length is > 1 in case first choices fail
-  */
-  chooseAuthorityToHostDoc ({ docId, groupId = null }) {
-    check(docId, String);
-    check(groupId, Match.Maybe(String));
-    // if there is already a server hosting this groupId, use it so they all are hosted together
-    if (groupId) {
-      const authorityHostingGroup = this.getAuthorityInfoByGroupId({ groupId });
-      if (authorityHostingGroup) {
-        console.log(`ProseMeteor AuthorityRegistry: Found an authority hosting groupId "${groupId}", selecting it to host docId "${docId}"`);
-        return [authorityHostingGroup];
-      }
-    }
+  getEligibleAuthoritiesToHostDoc () {
     // otherwise get 1-5 servers hosting the lowest number of docs
     const fullRegistry = this.fullRegistry();
     const fullRegistrySortedByDocIdsCount = fullRegistry
@@ -348,7 +312,7 @@ export class AuthorityRegistry {
         return authorityA.docIds.length > authorityB.docIds.lenth;
       })
       .slice(0, 5);
-    console.log(`ProseMeteor AuthorityRegistry: Selecting authority servers with least documents in order: "${JSON.stringify(fullRegistrySortedByDocIdsCount, null, 2)}"`);
+    console.log(`ProseMeteor AuthorityRegistry: Selecting eligible authority servers with least documents: "${JSON.stringify(fullRegistrySortedByDocIdsCount, null, 2)}"`);
 
     return fullRegistrySortedByDocIdsCount;
   }

--- a/lib/imports/api/authority-registry/server/authority-registry.js
+++ b/lib/imports/api/authority-registry/server/authority-registry.js
@@ -1,0 +1,22 @@
+export class AuthorityRegistry {
+  registerAuthority({ authorityIp }) {
+    // insert { authorityIp, docIds: [] } into collection
+  }
+  unregisterAuthority({ authorityIp }) {
+    // remove from collection
+  }
+  addDocToAuthority({ authorityIp, docId }) {
+    // delegate the doc to the specified authority
+  }
+  removeDocFromAuthority({ docId }) {
+    // remove a doc from its authority
+  }
+  getAuthorityIpHostingDoc({ docId }) {
+    // return ip of authority, or undefined
+  }
+  chooseAuthorityToHostDoc({ docId }) {
+    // -queries collection for all authorities
+    // -gets ip of last selected authority from db
+    // -iterate over authorities in sorted order. choose the one AFTER the last one selected
+  }
+}

--- a/lib/imports/api/authority-registry/server/authority-registry.js
+++ b/lib/imports/api/authority-registry/server/authority-registry.js
@@ -9,9 +9,12 @@ import { authorityRegistryColl } from './collection';
 import { WebApp } from 'meteor/webapp';
 import { HTTP } from 'meteor/http';
 import { check } from 'meteor/check';
+import ip from 'ip';
 
 export class AuthorityRegistry {
   constructor () {
+    this.ip = ip.address();
+    this.port = parseInt(process.env.PORT);
     this.failedHealthChecksThreshold = 3;
     // create a health check endpoint, so other servers can verify this server is alive or not
     WebApp.rawConnectHandlers.use(`/prosemeteor-health-check`, (req, res, next) => {
@@ -22,26 +25,24 @@ export class AuthorityRegistry {
       next();
     });
   }
-  register ({ ip, port }, cb) {
-    check(ip, String);
-    check(port, Number);
+  register (cb) {
     check(cb, Function);
     const insert = () => {
       // insert the server
-      insertAuthority.call({ ip, port }, (err, res) => {
+      insertAuthority.call({ ip: this.ip, port: this.port }, (err, res) => {
         if (err) {
           return cb(new Error(`Failed to insert Authority server into registry: ${err}`));
         }
-        console.log(`ProseMeteor AuthorityRegistry: Registered server in authority registry: ${ip}:${port}`);
+        console.log(`ProseMeteor AuthorityRegistry: Registered server in authority registry: ${this.ip}:${this.port}`);
         return cb(null, res);
       });
       // at the same time, start the health checks on all other servers
-      this.runHealthChecks({ thisServerIp: ip, thisServerPort: port });
+      this.runHealthChecks();
     };
     // check if this sever's already registered first
-    if (this.isRegistered({ ip, port })) {
+    if (this.isRegistered({ ip: this.ip, port: this.port })) {
       console.log(`ProseMeteor AuthorityRegistry: Authority server was already registered, clearing it out`);
-      removeAuthority.call({ ip }, (err, res) => {
+      removeAuthority.call({ ip: this.ip }, (err, res) => {
         if (err) {
           return cb(new Error(`Failed to remove existing authority server ${err}`));
         }
@@ -52,8 +53,6 @@ export class AuthorityRegistry {
     }
   }
   unregister ({ ip, port }, cb) {
-    check(ip, String);
-    check(port, Number);
     check(cb, Function);
     // remove from collection
     removeAuthority.call({ ip, port }, (err, res) => {
@@ -64,9 +63,7 @@ export class AuthorityRegistry {
       return cb(null, res);
     });
   }
-  runHealthChecks ({ thisServerIp, thisServerPort }) {
-    check(thisServerIp, String);
-    check(thisServerPort, Number);
+  runHealthChecks () {
     const fullRegistry = this.fullRegistry();
     const numServers = fullRegistry.length;
     let failedConnections = [];                       // _ids of all servers that failed checks, that didn't pass the threshold
@@ -75,7 +72,7 @@ export class AuthorityRegistry {
     console.log(`ProseMeteor AuthorityRegistry: Starting health checks for ${numServers} servers`);
     // do a check on each server
     fullRegistry.forEach(({ _id, ip, port, failedHealthChecks }) => {
-      if (ip === thisServerIp && port === thisServerPort) {
+      if (ip === this.ip && port === this.port) {
         console.log(`ProseMeteor AuthorityRegistry: Skipping this server's health check`);
         return;
       }

--- a/lib/imports/api/authority-registry/server/authority-registry.js
+++ b/lib/imports/api/authority-registry/server/authority-registry.js
@@ -17,6 +17,10 @@ const HEALTH_CHECK_RESPONSE = 'ProseMeteor Health OK';
 const FAILED_HEALTH_CHECKS_THRESHOLD = 5;
 const HEALTH_CHECK_INTERVAL_MS = 1000 * 30;   // interval on which to run health checks
 
+/**
+*   Class that manages and communicates with the authority registry. Maintains a list of all
+*   authority servers.
+*/
 export class AuthorityRegistry {
   constructor () {
     this.ip = ip.address();

--- a/lib/imports/api/authority-registry/server/authority-registry.js
+++ b/lib/imports/api/authority-registry/server/authority-registry.js
@@ -1,22 +1,21 @@
 import {
-  insertAuthority,
-  removeAuthority,
-  storeFailedHealthChecks,
-  removeAuthorities,
-  resetFailedHealthChecksCount,
-  addDocToAuthority
+  insertAuthorityServerIntoRegistry,
+  removeAuthorityServerFromRegistry,
+  addDocToAuthorityServer,
+  removeDocFromAuthorityServer
 } from './methods';
 import { authorityRegistryColl } from './collection';
 import { WebApp } from 'meteor/webapp';
-import { HTTP } from 'meteor/http';
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import ip from 'ip';
-
-const HTTPS_PORT = 443;
-const HEALTH_CHECK_RESPONSE = 'ProseMeteor Health OK';
-const FAILED_HEALTH_CHECKS_THRESHOLD = 5;
-const HEALTH_CHECK_INTERVAL_MS = 1000 * 30;   // interval on which to run health checks
+import { proseMeteorConfig } from './../../config/server/prosemeteor-config';
+import {
+  checkHealthOfServers,
+  storeHealthCheckResults,
+  removeDeadServersFromRegistry,
+  HEALTH_CHECK_RESPONSE
+} from './health-checks';
 
 /**
 *   Class that manages and communicates with the authority registry. Maintains a list of all
@@ -24,12 +23,12 @@ const HEALTH_CHECK_INTERVAL_MS = 1000 * 30;   // interval on which to run health
 */
 export class AuthorityRegistry {
   constructor () {
-    this.ip = ip.address();
-    this.port = parseInt(process.env.PORT);
+    proseMeteorConfig.ip = ip.address();
+    proseMeteorConfig.port = parseInt(process.env.PORT);
 
-    const ipAndPort = `${this.ip}:${this.port}`;
-    this.fullUrl = (this.port === HTTPS_PORT) ? `https://${ipAndPort}` : `http://${ipAndPort}`;
-    console.log(`ProseMeteor AuthorityRegistry, this server url: ${this.ipAndPort}`);
+    const ipAndPort = `${proseMeteorConfig.ip}:${proseMeteorConfig.port}`;
+    this.fullUrl = `${proseMeteorConfig.protocol}://${ipAndPort}`;
+    console.log(`ProseMeteor AuthorityRegistry, this server url: ${this.fullUrl}`);
 
     // bind class methods
     this.setUpHealthCheckEndpoint = this.setUpHealthCheckEndpoint.bind(this);
@@ -74,7 +73,7 @@ export class AuthorityRegistry {
   startHealthCheckInterval () {
     Meteor.setInterval(() => {
       this.runHealthChecks(this.fullRegistry());
-    }, HEALTH_CHECK_INTERVAL_MS);
+    }, proseMeteorConfig.healthCheckIntervalMs);
   }
   /**
   *  Register this app server as an authority server that is ready to host document authorities, storing
@@ -85,20 +84,20 @@ export class AuthorityRegistry {
     check(cb, Function);
     const insert = () => {
       // insert the server
-      insertAuthority.call({ ip: this.ip, port: this.port }, (err, res) => {
+      insertAuthorityServerIntoRegistry.call({ ip: proseMeteorConfig.ip, port: proseMeteorConfig.port }, (err, res) => {
         if (err) {
           return cb(new Error(`Failed to insert Authority server into registry: ${err}`));
         }
-        console.log(`ProseMeteor AuthorityRegistry: Registered server in authority registry: ${this.ip}:${this.port}`);
+        console.log(`ProseMeteor AuthorityRegistry: Registered server in authority registry: ${proseMeteorConfig.ip}:${proseMeteorConfig.port}`);
         return cb(null, res);
       });
       // at the same time, start the health checks on all other servers
       this.runHealthChecks(this.fullRegistry());
     };
     // check if this sever's already registered first
-    if (this.isRegistered({ ip: this.ip, port: this.port })) {
+    if (this.isRegistered({ ip: proseMeteorConfig.ip, port: proseMeteorConfig.port })) {
       console.log('ProseMeteor AuthorityRegistry: Authority server was already registered, clearing it out');
-      removeAuthority.call({ ip: this.ip }, (err, res) => {
+      removeAuthorityServerFromRegistry.call({ ip: proseMeteorConfig.ip, port: proseMeteorConfig.port }, (err, res) => {
         if (err) {
           return cb(new Error(`Failed to remove existing authority server ${err}`));
         }
@@ -120,7 +119,7 @@ export class AuthorityRegistry {
     check(port, Number);
     check(cb, Function);
     // remove from collection
-    removeAuthority.call({ ip, port }, (err, res) => {
+    removeAuthorityServerFromRegistry.call({ ip, port }, (err, res) => {
       if (err) {
         return cb(new Error(`Failed to remove Authority server from registry: ${err}`));
       }
@@ -152,76 +151,26 @@ export class AuthorityRegistry {
   */
   runHealthChecks (serversArray) {
     const numServers = serversArray.length;
-    let failedConnections = [];                       // _ids of all servers that failed checks, that didn't pass the threshold
-    let failedConnectionsAboveThreshold = [];         // _ids of all servers that failed checks, that did pass the threshold
-    let successfullChecksThatFailedPreviously = [];   // _ids of all servers that had a previous failure but passed this time, without passing the threshold
     console.log(`ProseMeteor AuthorityRegistry: Starting health checks for ${numServers} servers at time: ${new Date()}`);
-    console.log(`Health checks server array: ${JSON.stringify(serversArray, null, 2)}`);
-    // do a check on each server
-    serversArray.forEach(({ _id, ip, port, fullUrl, failedHealthChecks }) => {
-      console.log(`ProseMeteor AuthorityRegistry: running health check against ${fullUrl}`);
-      if (ip === this.ip && port === this.port) {
-        console.log('ProseMeteor AuthorityRegistry: Skipping this server\'s health check');
-        return;
-      }
-      // if this server has failed too many times, remove it from the registry since we can assume it's down
-      if (failedHealthChecks >= FAILED_HEALTH_CHECKS_THRESHOLD) {
-        console.log(`ProseMeteor AuthorityRegistry: ${ip}:${port} has failed ${failedHealthChecks} consecutive health checks, marking it to be removed from the registry`);
-        failedConnectionsAboveThreshold.push(_id);
-        return;
-      }
-      const healthCheckUrl = `${ip}:${port}/prosemeteor-health-check`;
-      // use http or https depending on port
-      const healthCheckUrlWithProtocol = (port === HTTPS_PORT) ? `https://${healthCheckUrl}` : `http://${healthCheckUrl}`;
-      let healthCheckRes;
-      let healthCheckFailed = false;
-      try {
-        healthCheckRes = HTTP.get(healthCheckUrlWithProtocol);
-        if (healthCheckRes !== HEALTH_CHECK_RESPONSE) {
-          healthCheckFailed = true;
-        }
-      } catch (e) {
-        healthCheckFailed = true;
-      }
-      if (healthCheckFailed) {
-        failedConnections.push(_id);
-      } else {
-        console.log(`ProseMeteor AuthorityRegistry: Server passed health check: ${ip}:${port}`);
-        // if this server failed a previous health check but passed this time, mark it to reset its failedHealthChecks count
-        if (failedHealthChecks > 0) {
-          successfullChecksThatFailedPreviously.push(_id);
-        }
-      }
-    });
+    console.log(`ProseMeteor AuthorityRegitsry: Health checks server array: ${JSON.stringify(serversArray, null, 2)}`);
+
+    // check health of all servers and get results
+    const {
+      failedConnections,
+      failedConnectionsAboveThreshold,
+      successfulChecksThatFailedPreviously
+    } = checkHealthOfServers(serversArray);
     console.log(`ProseMeteor AuthorityRegistry: Finished health checks. failed connections (${failedConnections.length} of ${numServers}): ${JSON.stringify(failedConnections, null, 2)}`);
     console.log(`ProseMeteor AuthorityRegistry: Finished health checks. failedConnectionsAboveThreshold: ${JSON.stringify(failedConnectionsAboveThreshold, null, 2)}`);
-    // store any failures
-    if (failedConnections.length > 0) {
-      try {
-        storeFailedHealthChecks.call({ _ids: failedConnections });
-        console.log('ProseMeteor AuthorityRegistry: Successfully stored failed health checks');
-      } catch (e) {
-        console.log(`ProseMeteor AuthorityRegistry: Failed to store failed health checks: ${e}`);
-      }
-    }
-    // reset failed health check count on servers that failed < threshold previously, and now passed
-    if (successfullChecksThatFailedPreviously.length > 0) {
-      try {
-        resetFailedHealthChecksCount.call({ _ids: successfullChecksThatFailedPreviously });
-        console.log(`ProseMeteor AuthorityRegistry: Reset the failed health checks count for ${successfullChecksThatFailedPreviously.length} servers: ${successfullChecksThatFailedPreviously}`);
-      } catch (e) {
-        console.log(`ProseMeteor AuthorityRegistry: Failed to reset the failed health checks count for ${successfullChecksThatFailedPreviously.length} servers: ${e}`);
-      }
-    }
-    // remove servers that have failed too many health checks
-    if (failedConnectionsAboveThreshold.length > 0) {
-      try {
-        removeAuthorities.call({ _ids: failedConnectionsAboveThreshold });
-        console.log(`ProseMeteor AuthorityRegistry: Removed ${failedConnectionsAboveThreshold.length} authorities from the registry because of failed health checks`);
-      } catch (e) {
-        console.log(`ProseMeteor AuthorityRegistry: Failed to remove authorities ${failedConnectionsAboveThreshold}: ${e}`);
-      }
-    }
+
+    // store the results of health checks
+    storeHealthCheckResults({
+      failedConnections,
+      successfulChecksThatFailedPreviously
+    });
+
+    // remove any dead servers from the registry
+    removeDeadServersFromRegistry({ failedConnectionsAboveThreshold });
 
     // return total number of bad connections, combining failedConnections with failedConnectionsAboveThreshold
     return failedConnections.concat(failedConnectionsAboveThreshold).length;
@@ -282,8 +231,8 @@ export class AuthorityRegistry {
   * @param {String} params.docId      unique id for this doc
   * @param {String} [params.groupId]  optional, a groupId of this doc to associate it with other docs
   */
-  addDocToAuthority ({ docId, groupId = null }) {
-    addDocToAuthority.call({ docId, groupId, fullUrl: this.fullUrl });
+  addDocToAuthorityServer ({ docId, groupId = null }) {
+    addDocToAuthorityServer.call({ docId, groupId, fullUrl: this.fullUrl });
     console.log(`ProseMeteor AuthorityRegistry: Added doc ${docId} to authority ${this.fullUrl}. Updated registry: ${JSON.stringify(this.fullRegistry(), null, 2)}`);
   }
   /**
@@ -293,12 +242,9 @@ export class AuthorityRegistry {
   * @param {String} params.docId      unique id for this doc
   * @param {String} [params.groupId]  optional, a groupId of this doc to associate it with other docs
   */
-  removeDocFromAuthority ({ docId, groupId = null }) {
+  removeDocFromAuthorityServer ({ docId, groupId = null }) {
     // first remove this docId
-
-    if (groupId) {
-      // check each remaining docId. if any have the same groupId, keep this docs groupId. otherwise remove it from groupIds[]
-    }
+    removeDocFromAuthorityServer.call({ docId, groupId, fullUrl: this.fullUrl });
   }
   /**
   *  Chooses a list of eligible authority servers to host a document, preferring the server with the least documents.

--- a/lib/imports/api/authority-registry/server/authority-registry.js
+++ b/lib/imports/api/authority-registry/server/authority-registry.js
@@ -1,14 +1,13 @@
-import { insertAuthority, removeAuthority } from './methods';
+import { insertAuthority, removeAuthority, storeFailedHealthChecks, removeAuthorities } from './methods';
 import { authorityRegistryColl } from './collection';
 import { WebApp } from 'meteor/webapp';
 import { HTTP } from 'meteor/http';
 
 export class AuthorityRegistry {
   constructor () {
+    this.failedHealthChecksThreshold = 3;
     // create a health check endpoint, so other servers can verify this server is alive or not
     WebApp.rawConnectHandlers.use(`/prosemeteor-health-check`, (req, res, next) => {
-      console.log(`--req:`, req);
-      console.log(`--res:`, res);
       res.writeHead(200, {
         'Content-Type': `text/plain`
       });
@@ -23,14 +22,15 @@ export class AuthorityRegistry {
         if (err) {
           return cb(new Error(`Failed to insert Authority server into registry: ${err}`));
         }
+        console.log(`ProseMeteor AuthorityRegistry: Registered server in authority registry: ${ip}:${port}`);
         return cb(null, res);
       });
       // at the same time, start the health checks on all other servers
-      this.runHealthChecks();
+      this.runHealthChecks({ thisServerIp: ip, thisServerPort: port });
     };
     // check if this sever's already registered first
     if (this.isRegistered({ ip, port })) {
-      console.log(`Authority server is already registered, clearing it out`);
+      console.log(`ProseMeteor AuthorityRegistry: Authority server was already registered, clearing it out`);
       removeAuthority.call({ ip }, (err, res) => {
         if (err) {
           return cb(new Error(`Failed to remove existing authority server ${err}`));
@@ -41,61 +41,90 @@ export class AuthorityRegistry {
       return insert();
     }
   }
-
-  runHealthChecks () {
-    const fullRegistry = this.fullRegistry();
-    const numServers = fullRegistry.length;
-    console.log(`---starting health checks for ${numServers} servers`);
-    // let numServerChecked = 0;
-    fullRegistry.forEach(({ ip, port }) => {
-      const healthCheckUrl = `${ip}:${port}/prosemeteor-health-check`;
-      const httpUrl = `http://${healthCheckUrl}`;
-      const httpsUrl = `https://${healthCheckUrl}`;
-      let httpRes;
-      let httpsRes;
-      try {
-        httpRes = HTTP.get(httpUrl);
-      } catch (e) {
-        console.log(`httpRes failed ${e}`);
-      }
-      try {
-        httpsRes = HTTP.get(httpsUrl);
-      } catch (e) {
-        console.log(`httpsRes failed ${e}`);
-      }
-      if (httpRes) {
-        console.log(`---http res: ${httpRes}`);
-      }
-      if (httpsRes) {
-        console.log(`---https res: ${httpsRes}`);
-      }
-      // const res = HTTP.get(healthCheckUrl, (err, res) => {
-      //   console.log(`--------${healthCheckUrl}`);
-      //   console.log(`--err: ${err}`);
-      //   console.log(`--res ${res}`);
-      // });
-    });
-    console.log(`---finished health checks`);
-  }
   unregister ({ ip, port }, cb) {
     // remove from collection
     removeAuthority.call({ ip, port }, (err, res) => {
       if (err) {
         return cb(new Error(`Failed to remove Authority server from registry: ${err}`));
       }
-      console.log(`Unregistered authority server with ip ${ip}`);
+      console.log(`ProseMeteor AuthorityRegistry: Unregistered authority server with ip ${ip}`);
       return cb(null, res);
     });
   }
+  runHealthChecks ({ thisServerIp, thisServerPort }) {
+    const fullRegistry = this.fullRegistry();
+    const numServers = fullRegistry.length;
+    let failedConnections = [];
+    let failedConnectionsAboveThreshold = [];
+    console.log(`ProseMeteor AuthorityRegistry: Starting health checks for ${numServers} servers`);
+    // do a check on each server
+    fullRegistry.forEach(({ _id, ip, port, failedHealthChecks }) => {
+      if (ip === thisServerIp && port === thisServerPort) {
+        console.log(`ProseMeteor AuthorityRegistry: Skipping this server's health check`);
+        return;
+      }
+      // if this server has failed too many times, remove it from the registry since we can assume it's down
+      if (failedHealthChecks >= this.failedHealthChecksThreshold) {
+        console.log(`ProseMeteor AuthorityRegistry: ${ip}:${port} has failed ${failedHealthChecks} consecutive health checks, marking it to be removed from the registry`);
+        failedConnectionsAboveThreshold.push(_id);
+        return;
+      }
+      const healthCheckUrl = `${ip}:${port}/prosemeteor-health-check`;
+      const httpUrl = `http://${healthCheckUrl}`;
+      const httpsUrl = `https://${healthCheckUrl}`;
+      let httpRes;
+      let httpsRes;
+      let httpFailed = false;
+      let httpsFailed = false;
+      try {
+        httpRes = HTTP.get(httpUrl);
+      } catch (e) {
+        // console.log(`ProseMeteor AuthorityRegistry: httpRes failed ${e}`);
+        httpFailed = true;
+      }
+      try {
+        httpsRes = HTTP.get(httpsUrl);
+      } catch (e) {
+        // console.log(`ProseMeteor AuthorityRegistry: httpsRes failed ${e}`);
+        httpsFailed = true;
+      }
+      if (httpRes) {
+        // console.log(`ProseMeteor AuthorityRegistry: ---http res: ${httpRes}`);
+      }
+      if (httpsRes) {
+        // console.log(`ProseMeteor AuthorityRegistry: ---https res: ${httpsRes}`);
+      }
+      if (httpFailed && httpsFailed) {
+        failedConnections.push(_id);
+      }
+    });
+    console.log(`ProseMeteor AuthorityRegistry: Finished health checks. failed connections (${failedConnections.length} of ${numServers}): ${failedConnections}`);
 
+    // store any failures
+    if (failedConnections.length > 0) {
+      storeFailedHealthChecks.call({ _ids: failedConnections }, (err, res) => {
+        if (err) {
+          console.log(`ProseMeteor AuthorityRegistry: Failed to store failed health checks: ${err}`);
+        }
+        console.log(`ProseMeteor AuthorityRegistry: Successfully stored failed health checks`);
+      });
+    }
+    if (failedConnectionsAboveThreshold.length > 0) {
+    // remove servers that have failed too many health checks
+      removeAuthorities.call({ _ids: failedConnectionsAboveThreshold }, (err) => {
+        if (err) {
+          console.log(`ProseMeteor AuthorityRegistry: Failed to remove authorities ${failedConnectionsAboveThreshold}: ${err}`);
+        }
+        console.log(`ProseMeteor AuthorityRegistry: Removed ${failedConnectionsAboveThreshold.length} authorities from the registry because of failed health checks`);
+      });
+    }
+  }
   fullRegistry () {
     return authorityRegistryColl.find({}).fetch();
   }
-
   isRegistered ({ ip, port }) {
     return authorityRegistryColl.find({ ip, port }).count() !== 0;
   }
-
   addDocToAuthority ({ ip, docId }) {
     // delegate the doc to the specified authority
   }

--- a/lib/imports/api/authority-registry/server/collection.js
+++ b/lib/imports/api/authority-registry/server/collection.js
@@ -1,0 +1,20 @@
+import { Mongo } from 'meteor/mongo';
+
+// todo: the collection name and field names should probably be configurable
+export const authorityRegistryColl = new Mongo.Collection('Documents');
+
+// Deny all client-side updates since we will be using methods to manage this collection
+authorityRegistryColl.deny({
+  insert() { return true; },
+  update() { return true; },
+  remove() { return true; }
+});
+
+// class Documents extends Mongo.Collection {
+//   insert(document, callback) {
+//     return super.insert(document, callback);
+//   }
+//   remove(selector, callback) {
+//     return super.remove(selector, callback);
+//   }
+// }

--- a/lib/imports/api/authority-registry/server/collection.js
+++ b/lib/imports/api/authority-registry/server/collection.js
@@ -1,7 +1,7 @@
 import { Mongo } from 'meteor/mongo';
 
 // todo: the collection name and field names should probably be configurable
-export const authorityRegistryColl = new Mongo.Collection(`prosemeteor-authority-registry`);
+export const authorityRegistryColl = new Mongo.Collection('prosemeteor-authority-registry');
 
 // Deny all client-side updates since we will be using methods to manage this collection
 authorityRegistryColl.deny({

--- a/lib/imports/api/authority-registry/server/collection.js
+++ b/lib/imports/api/authority-registry/server/collection.js
@@ -1,7 +1,7 @@
 import { Mongo } from 'meteor/mongo';
 
 // todo: the collection name and field names should probably be configurable
-export const authorityRegistryColl = new Mongo.Collection('Documents');
+export const authorityRegistryColl = new Mongo.Collection('prosemeteor-authority-registry');
 
 // Deny all client-side updates since we will be using methods to manage this collection
 authorityRegistryColl.deny({
@@ -9,12 +9,3 @@ authorityRegistryColl.deny({
   update() { return true; },
   remove() { return true; }
 });
-
-// class Documents extends Mongo.Collection {
-//   insert(document, callback) {
-//     return super.insert(document, callback);
-//   }
-//   remove(selector, callback) {
-//     return super.remove(selector, callback);
-//   }
-// }

--- a/lib/imports/api/authority-registry/server/health-checks.js
+++ b/lib/imports/api/authority-registry/server/health-checks.js
@@ -1,0 +1,113 @@
+/**
+* Module for methods that assist health check logic.
+*/
+import { proseMeteorConfig } from './../../config/server/prosemeteor-config';
+import { HTTP } from 'meteor/http';
+import {
+  storeFailedHealthChecks,
+  resetFailedHealthChecksCount,
+  removeAuthorities
+} from './methods';
+
+// response body that health check endpoint returns
+export const HEALTH_CHECK_RESPONSE = 'ProseMeteor Health OK';
+
+/**
+* Sends requests to each server's health check endpoint and returns the results.
+*
+* @param {Array} serversArray         arry of server entries from the registry in db to run health checks against
+*/
+export const checkHealthOfServers = (serversArray) => {
+  let failedConnections = [];                       // _ids of all servers that failed checks, that didn't pass the threshold
+  let failedConnectionsAboveThreshold = [];         // _ids of all servers that failed checks, that did pass the threshold
+  let successfulChecksThatFailedPreviously = [];    // _ids of all servers that had a previous failure but passed this time, without passing the threshold
+  // do a check on each server
+  serversArray.forEach(({ _id, ip, port, fullUrl, failedHealthChecks }) => {
+    console.log(`ProseMeteor AuthorityRegistry: running health check against ${fullUrl}`);
+    if (ip === proseMeteorConfig.ip && port === proseMeteorConfig.port) {
+      console.log('ProseMeteor AuthorityRegistry: Skipping this server\'s health check');
+      return;
+    }
+    // if this server has failed too many times, remove it from the registry since we can assume it's down
+    if (failedHealthChecks >= proseMeteorConfig.failedHealthChecksThreshold) {
+      console.log(`ProseMeteor AuthorityRegistry: ${ip}:${port} has failed ${failedHealthChecks} consecutive health checks, marking it to be removed from the registry`);
+      failedConnectionsAboveThreshold.push(_id);
+      return;
+    }
+    const healthCheckUrl = `${ip}:${port}/prosemeteor-health-check`;
+    // use http or https depending on port
+    const healthCheckUrlWithProtocol = `${proseMeteorConfig.protocol}://${healthCheckUrl}`;
+    let healthCheckRes;
+    let healthCheckFailed = false;
+    try {
+      healthCheckRes = HTTP.get(healthCheckUrlWithProtocol);
+      if (healthCheckRes !== HEALTH_CHECK_RESPONSE) {
+        healthCheckFailed = true;
+      }
+    } catch (e) {
+      healthCheckFailed = true;
+    }
+    if (healthCheckFailed) {
+      failedConnections.push(_id);
+    } else {
+      console.log(`ProseMeteor AuthorityRegistry: Server passed health check: ${ip}:${port}`);
+      // if this server failed a previous health check but passed this time, mark it to reset its failedHealthChecks count
+      if (failedHealthChecks > 0) {
+        successfulChecksThatFailedPreviously.push(_id);
+      }
+    }
+  });
+  return {
+    failedConnections,
+    failedConnectionsAboveThreshold,
+    successfulChecksThatFailedPreviously
+  };
+};
+
+/**
+* Stores the results of health checks for each server.
+*
+* @param {Object} params
+* @param {Array} params.failedConnections                     array of _id's of servers who have failed the health check
+* @param {Array} params.successfulChecksThatFailedPreviously  array of _id's of servers who have passed the health check but failed previously
+*/
+export const storeHealthCheckResults = ({
+  failedConnections,
+  successfulChecksThatFailedPreviously
+}) => {
+  if (failedConnections.length > 0) {
+    try {
+      storeFailedHealthChecks.call({ _ids: failedConnections });
+      console.log('ProseMeteor AuthorityRegistry: Successfully stored failed health checks');
+    } catch (e) {
+      console.log(`ProseMeteor AuthorityRegistry: Failed to store failed health checks: ${e}`);
+    }
+  }
+  // reset failed health check count on servers that failed < threshold previously, and now passed
+  if (successfulChecksThatFailedPreviously.length > 0) {
+    try {
+      resetFailedHealthChecksCount.call({ _ids: successfulChecksThatFailedPreviously });
+      console.log(`ProseMeteor AuthorityRegistry: Reset the failed health checks count for ${successfulChecksThatFailedPreviously.length} servers: ${successfulChecksThatFailedPreviously}`);
+    } catch (e) {
+      console.log(`ProseMeteor AuthorityRegistry: Failed to reset the failed health checks count for ${successfulChecksThatFailedPreviously.length} servers: ${e}`);
+    }
+  }
+};
+
+/**
+* Removes servers that have failed too many consecutive health checks from the registry.
+*
+* @param {Object} params
+* @param {Array} params.failedConnectionsAboveThreshold  array of _id's of servers who have failed too many health checks and need to be removed
+*/
+export const removeDeadServersFromRegistry = ({ failedConnectionsAboveThreshold }) => {
+  // remove servers that have failed too many health checks
+  if (failedConnectionsAboveThreshold.length > 0) {
+    try {
+      removeAuthorities.call({ _ids: failedConnectionsAboveThreshold });
+      console.log(`ProseMeteor AuthorityRegistry: Removed ${failedConnectionsAboveThreshold.length} authorities from the registry because of failed health checks`);
+    } catch (e) {
+      console.log(`ProseMeteor AuthorityRegistry: Failed to remove authorities ${failedConnectionsAboveThreshold}: ${e}`);
+    }
+  }
+};

--- a/lib/imports/api/authority-registry/server/methods.js
+++ b/lib/imports/api/authority-registry/server/methods.js
@@ -14,12 +14,14 @@ export const insertAuthority = new ValidatedMethod({
   name: 'authorityRegistry.insertAuthority',
   validate(args) {
     check(args, {
-      authorityIp: String
+      authorityIp: String,
+      port: Number
     });
   },
-  run({ authorityIp }) {
+  run({ authorityIp, port }) {
     const authorityDoc = {
       authorityIp,
+      port,
       docIds: []
     };
 
@@ -28,7 +30,7 @@ export const insertAuthority = new ValidatedMethod({
       _id,
       ...authorityDoc
     };
-    console.log('Registered Authority in registry: ', authorityIp);
+    console.log(`Registered Authority in registry: ${authorityIp}:${port}`);
     return authorityDocWithId;
   }
 });
@@ -37,11 +39,12 @@ export const removeAuthority = new ValidatedMethod({
   name: 'authorityRegistry.removeAuthority',
   validate(args) {
     check(args, {
-      authorityIp: String
+      authorityIp: String,
+      port: Number
     });
   },
-  run({ authorityIp }) {
-    console.log('Unregistered Authority in registry: ', authorityIp);
+  run({ authorityIp, port }) {
+    console.log(`Unregistered Authority in registry: ${authorityIp}:${port}`);
 
     return authorityRegistryColl.remove({ authorityIp });
   }

--- a/lib/imports/api/authority-registry/server/methods.js
+++ b/lib/imports/api/authority-registry/server/methods.js
@@ -1,8 +1,7 @@
 import { check, Match } from 'meteor/check';
 import { authorityRegistryColl } from './collection';
 import { ValidatedMethod } from 'meteor/mdg:validated-method';
-
-const HTTPS_PORT = 443;
+import { proseMeteorConfig } from './../../config/server/prosemeteor-config';
 
 /*
 Authority schema looks like this
@@ -13,9 +12,20 @@ Authority schema looks like this
  docIds: ['xyz321','foo837','bar221'],
  recentFailedConnectionTimes: [13662212879613, 13662212879721, 1366221289532]
 }
+
 */
-export const insertAuthority = new ValidatedMethod({
-  name: 'authorityRegistry.insertAuthority',
+
+/**
+* Inserts a new authority server into the registry. An authority server represents a server
+* that is capable of and ready to host ProseMeteorAuthority instances that track a single
+* ProseMeteor document.
+*
+* @param {Object} params
+* @param {String} params.ip     ip of the server
+* @param {Number} params.port   port of the server
+*/
+export const insertAuthorityServerIntoRegistry = new ValidatedMethod({
+  name: 'authorityRegistry.insertAuthorityServerIntoRegistry',
   validate (args) {
     check(args, {
       ip: String,
@@ -23,12 +33,12 @@ export const insertAuthority = new ValidatedMethod({
     });
   },
   run ({ ip, port }) {
-    const fullUrl = `${ip}:${port}`;
-    const fullUrlWithProtocol = (this.port === HTTPS_PORT) ? `https://${fullUrl}` : `http://${fullUrl}`;
+    const ipAndPort = `${ip}:${port}`;
+    const fullUrl = `${proseMeteorConfig.protocol}://${ipAndPort}`;
     const authorityDoc = {
       ip,
       port,
-      fullUrl: fullUrlWithProtocol,
+      fullUrl,
       docIds: [],
       groupIds: [],
       failedHealthChecks: 0
@@ -43,8 +53,15 @@ export const insertAuthority = new ValidatedMethod({
   }
 });
 
-export const removeAuthority = new ValidatedMethod({
-  name: 'authorityRegistry.removeAuthority',
+/**
+* Removes an authority server from the registry.
+*
+* @param {Object} params
+* @param {String} params.ip     ip of the server
+* @param {Number} params.port   port of the server
+*/
+export const removeAuthorityServerFromRegistry = new ValidatedMethod({
+  name: 'authorityRegistry.removeAuthorityServerFromRegistry',
   validate (args) {
     check(args, {
       ip: String,
@@ -56,8 +73,16 @@ export const removeAuthority = new ValidatedMethod({
   }
 });
 
-export const addDocToAuthority = new ValidatedMethod({
-  name: 'authorityRegistry.addDocToAuthority',
+/**
+* Adds a document to an authority server in the registry.
+*
+* @param {Object} params
+* @param {String} params.docId     id of the document
+* @param {Number} params.fullUrl   full url of the server
+* @param {String} [params.groupId] group id for the document
+*/
+export const addDocToAuthorityServer = new ValidatedMethod({
+  name: 'authorityRegistry.addDocToAuthorityServer',
   validate (args) {
     check(args, {
       docId: String,
@@ -88,26 +113,39 @@ export const addDocToAuthority = new ValidatedMethod({
   }
 });
 
-export const removeDocFromAuthority = new ValidatedMethod({
-  name: 'authorityRegistry.removeDocFromAuthority',
+/**
+* Removes a document from an authority server in the registry.
+*
+* @param {Object} params
+* @param {String} params.docId     id of the document
+* @param {Number} params.fullUrl   full url of the server
+* @param {String} [params.groupId] group id for the document
+*/
+export const removeDocFromAuthorityServer = new ValidatedMethod({
+  name: 'authorityRegistry.removeDocFromAuthorityServer',
   validate (args) {
     check(args, {
-      ip: String,
       docId: String,
       fullUrl: String,
-      groupId: Match.Maybe(String)
+      groupId: Match.OneOf(undefined, null, String)
     });
   },
-  run ({ ip, docId, fullUrl, groupId = null }) {
+  run ({ docId, fullUrl, groupId = null }) {
     // first remove this docId
-    authorityRegistryColl.update({ ip }, { $pull: { docIds: docId } });
+    authorityRegistryColl.update({ fullUrl }, { $pull: { docIds: docId } });
 
     if (groupId) {
-      // check each remaining docId. if any have the same groupId, keep this docs groupId. otherwise remove it from groupIds[]
+      // TODO: check each remaining docId. if any have the same groupId, keep this docs groupId. otherwise remove it from groupIds[]
     }
   }
 });
 
+/**
+* Stores failed health checks on the specified authority servers in the registry.
+*
+* @param {Object} params
+* @param {Array} params._ids     _ids of the servers that failed health checks
+*/
 export const storeFailedHealthChecks = new ValidatedMethod({
   name: 'authortiyRegistry.storeFailedHealthChecks',
   validate (args) {
@@ -120,6 +158,12 @@ export const storeFailedHealthChecks = new ValidatedMethod({
   }
 });
 
+/**
+* Resets the failed health checks count to zero on the specified authority servers in the registry.
+*
+* @param {Object} params
+* @param {Array} params._ids     _ids of the servers that need to have health check count reset
+*/
 export const resetFailedHealthChecksCount = new ValidatedMethod({
   name: 'authortiyRegistry.resetFailedHealthChecksCount',
   validate (args) {
@@ -132,6 +176,12 @@ export const resetFailedHealthChecksCount = new ValidatedMethod({
   }
 });
 
+/**
+* Entirely removes the spcified authority servers from the registry.
+*
+* @param {Object} params
+* @param {Array} params._ids     _ids of the servers that failed health checks
+*/
 export const removeAuthorities = new ValidatedMethod({
   name: 'authortiyRegistry.removeAuthorities',
   validate (args) {

--- a/lib/imports/api/authority-registry/server/methods.js
+++ b/lib/imports/api/authority-registry/server/methods.js
@@ -3,25 +3,26 @@ import { authorityRegistryColl } from './collection';
 import { ValidatedMethod } from 'meteor/mdg:validated-method';
 
 /*
-Document schema looks like this
+Authority schema looks like this
 {
  _id: 'abc123',
- authorityIp: '192.168.2.1',
+ ip: '192.168.2.1',
  port: 2976,
- docIds: ['xyz321','foo837','bar221']
+ docIds: ['xyz321','foo837','bar221'],
+ recentFailedConnectionTimes: [13662212879613, 13662212879721, 1366221289532]
 }
 */
 export const insertAuthority = new ValidatedMethod({
   name: `authorityRegistry.insertAuthority`,
   validate (args) {
     check(args, {
-      authorityIp: String,
+      ip: String,
       port: Number
     });
   },
-  run ({ authorityIp, port }) {
+  run ({ ip, port }) {
     const authorityDoc = {
-      authorityIp,
+      ip,
       port,
       docIds: []
     };
@@ -31,7 +32,7 @@ export const insertAuthority = new ValidatedMethod({
       _id,
       ...authorityDoc
     };
-    console.log(`Registered Authority in registry: ${authorityIp}:${port}`);
+    console.log(`Registered Authority in registry: ${ip}:${port}`);
     return authorityDocWithId;
   }
 });
@@ -40,13 +41,13 @@ export const removeAuthority = new ValidatedMethod({
   name: `authorityRegistry.removeAuthority`,
   validate (args) {
     check(args, {
-      authorityIp: String
+      ip: String
     });
   },
-  run ({ authorityIp, port }) {
-    console.log(`Unregistered Authority in registry: ${authorityIp}`);
+  run ({ ip, port }) {
+    console.log(`Unregistered Authority in registry: ${ip}`);
 
-    return authorityRegistryColl.remove({ authorityIp });
+    return authorityRegistryColl.remove({ ip });
   }
 });
 
@@ -54,14 +55,14 @@ export const addDocToAuthority = new ValidatedMethod({
   name: `authorityRegistry.addDocToAuthority`,
   validate (args) {
     check(args, {
-      authorityIp: String,
+      ip: String,
       docId: String
     });
   },
-  run ({ authorityIp, docId }) {
-    console.log(`Added doc ${docId} to Authority in registry: ${authorityIp}`);
+  run ({ ip, docId }) {
+    console.log(`Added doc ${docId} to Authority in registry: ${ip}`);
 
-    return authorityRegistryColl.update({ authorityIp }, { $push: { docIds: docId } });
+    return authorityRegistryColl.update({ ip }, { $push: { docIds: docId } });
   }
 });
 
@@ -69,13 +70,13 @@ export const removeDocFromAuthority = new ValidatedMethod({
   name: `authorityRegistry.removeDocFromAuthority`,
   validate (args) {
     check(args, {
-      authorityIp: String,
+      ip: String,
       docId: String
     });
   },
-  run ({ authorityIp, docId }) {
-    console.log(`Removed doc ${docId} from Authority in registry: ${authorityIp}`);
+  run ({ ip, docId }) {
+    console.log(`Removed doc ${docId} from Authority in registry: ${ip}`);
 
-    return authorityRegistryColl.update({ authorityIp }, { $pull: { docIds: docId } });
+    return authorityRegistryColl.update({ ip }, { $pull: { docIds: docId } });
   }
 });

--- a/lib/imports/api/authority-registry/server/methods.js
+++ b/lib/imports/api/authority-registry/server/methods.js
@@ -24,7 +24,8 @@ export const insertAuthority = new ValidatedMethod({
     const authorityDoc = {
       ip,
       port,
-      docIds: []
+      docIds: [],
+      failedHealthChecks: 0
     };
 
     const _id = authorityRegistryColl.insert(authorityDoc);
@@ -32,7 +33,6 @@ export const insertAuthority = new ValidatedMethod({
       _id,
       ...authorityDoc
     };
-    console.log(`Registered Authority in registry: ${ip}:${port}`);
     return authorityDocWithId;
   }
 });
@@ -46,8 +46,6 @@ export const removeAuthority = new ValidatedMethod({
     });
   },
   run ({ ip, port }) {
-    console.log(`Unregistered Authority in registry: ${ip}:${port}`);
-
     return authorityRegistryColl.remove({ ip, port });
   }
 });
@@ -61,8 +59,6 @@ export const addDocToAuthority = new ValidatedMethod({
     });
   },
   run ({ ip, docId }) {
-    console.log(`Added doc ${docId} to Authority in registry: ${ip}`);
-
     return authorityRegistryColl.update({ ip }, { $push: { docIds: docId } });
   }
 });
@@ -76,8 +72,30 @@ export const removeDocFromAuthority = new ValidatedMethod({
     });
   },
   run ({ ip, docId }) {
-    console.log(`Removed doc ${docId} from Authority in registry: ${ip}`);
-
     return authorityRegistryColl.update({ ip }, { $pull: { docIds: docId } });
+  }
+});
+
+export const storeFailedHealthChecks = new ValidatedMethod({
+  name: `authortiyRegistry.storeFailedHealthChecks`,
+  validate (args) {
+    check(args, {
+      _ids: Array
+    });
+  },
+  run ({ _ids }) {
+    return authorityRegistryColl.update({ _id: { $in: _ids } }, { $inc: { failedHealthChecks: 1 } }, { multi: true });
+  }
+});
+
+export const removeAuthorities = new ValidatedMethod({
+  name: `authortiyRegistry.removeAuthorities`,
+  validate (args) {
+    check(args, {
+      _ids: Array
+    });
+  },
+  run ({ _ids }) {
+    return authorityRegistryColl.remove({ _id: { $in: _ids } });
   }
 });

--- a/lib/imports/api/authority-registry/server/methods.js
+++ b/lib/imports/api/authority-registry/server/methods.js
@@ -1,4 +1,4 @@
-import { check } from 'meteor/check';
+import { check, Match } from 'meteor/check';
 import { authorityRegistryColl } from './collection';
 import { ValidatedMethod } from 'meteor/mdg:validated-method';
 
@@ -60,12 +60,31 @@ export const addDocToAuthority = new ValidatedMethod({
   name: 'authorityRegistry.addDocToAuthority',
   validate (args) {
     check(args, {
-      ip: String,
-      docId: String
+      docId: String,
+      fullUrl: String,
+      groupId: Match.OneOf(undefined, null, String)
     });
   },
-  run ({ ip, docId }) {
-    return authorityRegistryColl.update({ ip }, { $push: { docIds: docId } });
+  run ({ ip, docId, fullUrl, groupId }) {
+    if (groupId) {
+      // if groupId provided, add both docId and groupId to authority
+      return authorityRegistryColl.update({
+        fullUrl
+      }, {
+        $addToSet: {
+          docIds: docId,
+          groupIds: groupId
+        }
+      });
+    }
+    // if no groupId, only add docId to authority
+    return authorityRegistryColl.update({
+      fullUrl
+    }, {
+      $addToSet: {
+        docIds: docId
+      }
+    });
   }
 });
 
@@ -74,11 +93,18 @@ export const removeDocFromAuthority = new ValidatedMethod({
   validate (args) {
     check(args, {
       ip: String,
-      docId: String
+      docId: String,
+      fullUrl: String,
+      groupId: Match.Maybe(String)
     });
   },
-  run ({ ip, docId }) {
-    return authorityRegistryColl.update({ ip }, { $pull: { docIds: docId } });
+  run ({ ip, docId, fullUrl, groupId = null }) {
+    // first remove this docId
+    authorityRegistryColl.update({ ip }, { $pull: { docIds: docId } });
+
+    if (groupId) {
+      // check each remaining docId. if any have the same groupId, keep this docs groupId. otherwise remove it from groupIds[]
+    }
   }
 });
 

--- a/lib/imports/api/authority-registry/server/methods.js
+++ b/lib/imports/api/authority-registry/server/methods.js
@@ -2,6 +2,8 @@ import { check } from 'meteor/check';
 import { authorityRegistryColl } from './collection';
 import { ValidatedMethod } from 'meteor/mdg:validated-method';
 
+const HTTPS_PORT = 443;
+
 /*
 Authority schema looks like this
 {
@@ -21,9 +23,12 @@ export const insertAuthority = new ValidatedMethod({
     });
   },
   run ({ ip, port }) {
+    const fullUrl = `${ip}:${port}`;
+    const fullUrlWithProtocol = (this.port === HTTPS_PORT) ? `https://${fullUrl}` : `http://${fullUrl}`;
     const authorityDoc = {
       ip,
       port,
+      fullUrl: fullUrlWithProtocol,
       docIds: [],
       groupIds: [],
       failedHealthChecks: 0

--- a/lib/imports/api/authority-registry/server/methods.js
+++ b/lib/imports/api/authority-registry/server/methods.js
@@ -13,7 +13,7 @@ Authority schema looks like this
 }
 */
 export const insertAuthority = new ValidatedMethod({
-  name: `authorityRegistry.insertAuthority`,
+  name: 'authorityRegistry.insertAuthority',
   validate (args) {
     check(args, {
       ip: String,
@@ -25,6 +25,7 @@ export const insertAuthority = new ValidatedMethod({
       ip,
       port,
       docIds: [],
+      groupIds: [],
       failedHealthChecks: 0
     };
 
@@ -38,7 +39,7 @@ export const insertAuthority = new ValidatedMethod({
 });
 
 export const removeAuthority = new ValidatedMethod({
-  name: `authorityRegistry.removeAuthority`,
+  name: 'authorityRegistry.removeAuthority',
   validate (args) {
     check(args, {
       ip: String,
@@ -51,7 +52,7 @@ export const removeAuthority = new ValidatedMethod({
 });
 
 export const addDocToAuthority = new ValidatedMethod({
-  name: `authorityRegistry.addDocToAuthority`,
+  name: 'authorityRegistry.addDocToAuthority',
   validate (args) {
     check(args, {
       ip: String,
@@ -64,7 +65,7 @@ export const addDocToAuthority = new ValidatedMethod({
 });
 
 export const removeDocFromAuthority = new ValidatedMethod({
-  name: `authorityRegistry.removeDocFromAuthority`,
+  name: 'authorityRegistry.removeDocFromAuthority',
   validate (args) {
     check(args, {
       ip: String,
@@ -77,7 +78,7 @@ export const removeDocFromAuthority = new ValidatedMethod({
 });
 
 export const storeFailedHealthChecks = new ValidatedMethod({
-  name: `authortiyRegistry.storeFailedHealthChecks`,
+  name: 'authortiyRegistry.storeFailedHealthChecks',
   validate (args) {
     check(args, {
       _ids: Array
@@ -89,7 +90,7 @@ export const storeFailedHealthChecks = new ValidatedMethod({
 });
 
 export const resetFailedHealthChecksCount = new ValidatedMethod({
-  name: `authortiyRegistry.resetFailedHealthChecksCount`,
+  name: 'authortiyRegistry.resetFailedHealthChecksCount',
   validate (args) {
     check(args, {
       _ids: Array
@@ -101,7 +102,7 @@ export const resetFailedHealthChecksCount = new ValidatedMethod({
 });
 
 export const removeAuthorities = new ValidatedMethod({
-  name: `authortiyRegistry.removeAuthorities`,
+  name: 'authortiyRegistry.removeAuthorities',
   validate (args) {
     check(args, {
       _ids: Array

--- a/lib/imports/api/authority-registry/server/methods.js
+++ b/lib/imports/api/authority-registry/server/methods.js
@@ -88,6 +88,18 @@ export const storeFailedHealthChecks = new ValidatedMethod({
   }
 });
 
+export const resetFailedHealthChecksCount = new ValidatedMethod({
+  name: `authortiyRegistry.resetFailedHealthChecksCount`,
+  validate (args) {
+    check(args, {
+      _ids: Array
+    });
+  },
+  run ({ _ids }) {
+    return authorityRegistryColl.update({ _id: { $in: _ids } }, { $set: { failedHealthChecks: 0 } }, { multi: true });
+  }
+});
+
 export const removeAuthorities = new ValidatedMethod({
   name: `authortiyRegistry.removeAuthorities`,
   validate (args) {

--- a/lib/imports/api/authority-registry/server/methods.js
+++ b/lib/imports/api/authority-registry/server/methods.js
@@ -1,0 +1,70 @@
+import { check } from 'meteor/check';
+import { authorityRegistryColl } from './collection';
+import { ValidatedMethod } from 'meteor/mdg:validated-method';
+
+export const insertAuthority = new ValidatedMethod({
+  name: 'authorityRegistry.insertAuthority',
+  validate(args) {
+    check(args, {
+      authorityIp: String
+    });
+  },
+  run({ authorityIp }) {
+    const authorityDoc = {
+      authorityIp,
+      docIds: []
+    };
+
+    const _id = authorityRegistryColl.insert(authorityDoc);
+    let authorityDocWithId = {
+      _id,
+      ...authorityDoc
+    };
+    console.log('Registered Authority in registry: ', authorityIp);
+    return authorityDocWithId;
+  }
+});
+
+export const removeAuthority = new ValidatedMethod({
+  name: 'authorityRegistry.removeAuthority',
+  validate(args) {
+    check(args, {
+      authorityIp: String
+    });
+  },
+  run({ authorityIp }) {
+    console.log('Unregistered Authority in registry: ', authorityIp);
+
+    return authorityRegistryColl.remove({ authorityIp });
+  }
+});
+
+export const addDocToAuthority = new ValidatedMethod({
+  name: 'authorityRegistry.addDocToAuthority',
+  validate(args) {
+    check(args, {
+      authorityIp: String,
+      docId: String
+    });
+  },
+  run({ authorityIp, docId }) {
+    console.log('Added doc ' + docId + ' to Authority in registry: ', authorityIp);
+
+    return authorityRegistryColl.update({ authorityIp }, { $push: { docIds: docId } });
+  }
+});
+
+export const removeDocFromAuthority = new ValidatedMethod({
+  name: 'authorityRegistry.removeDocFromAuthority',
+  validate(args) {
+    check(args, {
+      authorityIp: String,
+      docId: String
+    });
+  },
+  run({ authorityIp, docId }) {
+    console.log('Removed doc ' + docId + ' from Authority in registry: ', authorityIp);
+
+    return authorityRegistryColl.update({ authorityIp }, { $pull: { docIds: docId } });
+  }
+});

--- a/lib/imports/api/authority-registry/server/methods.js
+++ b/lib/imports/api/authority-registry/server/methods.js
@@ -2,6 +2,14 @@ import { check } from 'meteor/check';
 import { authorityRegistryColl } from './collection';
 import { ValidatedMethod } from 'meteor/mdg:validated-method';
 
+/*
+Document schema looks like this
+{
+ _id: 'abc123',
+ authorityIp: '192.168.2.1',
+ docIds: ['xyz321','foo837','bar221']
+}
+*/
 export const insertAuthority = new ValidatedMethod({
   name: 'authorityRegistry.insertAuthority',
   validate(args) {

--- a/lib/imports/api/authority-registry/server/methods.js
+++ b/lib/imports/api/authority-registry/server/methods.js
@@ -41,13 +41,14 @@ export const removeAuthority = new ValidatedMethod({
   name: `authorityRegistry.removeAuthority`,
   validate (args) {
     check(args, {
-      ip: String
+      ip: String,
+      port: Number
     });
   },
   run ({ ip, port }) {
-    console.log(`Unregistered Authority in registry: ${ip}`);
+    console.log(`Unregistered Authority in registry: ${ip}:${port}`);
 
-    return authorityRegistryColl.remove({ ip });
+    return authorityRegistryColl.remove({ ip, port });
   }
 });
 

--- a/lib/imports/api/authority/server/authority-manager.js
+++ b/lib/imports/api/authority/server/authority-manager.js
@@ -1,7 +1,8 @@
 import { Authority } from './authority';
 import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
-import { check } from 'meteor/check';
+import { check, Match } from 'meteor/check';
+import { DDP } from 'meteor/ddp-client';
 import { AuthorityRegistry } from './../../authority-registry/server/authority-registry';
 
 export class AuthorityManager {
@@ -24,6 +25,15 @@ export class AuthorityManager {
     this.streamerServer = streamer;
     this.snapshotIntervalMs = snapshotIntervalMs;
     this.registry = new AuthorityRegistry();
+
+    // bind class methods
+    this.setupClientMethods = this.setupClientMethods.bind(this);
+    this.openDoc = this.openDoc.bind(this);
+    this.createAuthority = this.createAuthority.bind(this);
+    this.latestDocState = this.latestDocState.bind(this);
+    this.stepsSince = this.stepsSince.bind(this);
+    this.receiveSteps = this.receiveSteps.bind(this);
+
     this.registry.register((err, res) => {
       if (err) {
         console.error(`Failed to register Authority with AuthorityRegistry: ${err}`);
@@ -65,32 +75,80 @@ export class AuthorityManager {
         self.receiveSteps({ docId, clientId, version, stepsJSON });
       },
 
-      // open a doc, creating an authority for it
-      'ProseMeteor.openDoc' ({ docId }) {
+      // open a doc, setting up its authority
+      'ProseMeteor.openDoc' ({ docId, groupId = undefined }) {
         check(docId, String);
-        self.openDoc({ docId });
+        check(groupId, Match.Maybe(String));
+        return self.openDoc({ docId, groupId });
+      },
+
+      // creates an authority in memory
+      'ProseMeteor.createAuthority' ({ docId, groupId = undefined }) {
+        check(docId, String);
+        check(groupId, Match.Maybe(String));
+        self.createAuthority({ docId, groupId });
       }
     });
   }
 
   /**
-  * Open a ProseMirror document. Creates a new Authority to track the doc.
+  * Open a ProseMirror document. Instructs appropriate server to create a server in memory and returns the server's URL.
   * @param {Object} params
-  * @param {String} params.docId       the unique id of the doc
+  * @param {String} params.docId         the unique id of the doc
+  * @param {String} [params.groupId]     an id to associate this doc with other docs
   */
-  openDoc ({ docId }) {
-    check(docId, String);
-    if (!docId) {
-      throw new Meteor.Error('no-authority-exists', `This AuthorityManager doesn't have an Authority tracking a document with docId ${docId}.`);
-    }
-    // if we're already tracking this doc with an authority, we're all set
+  openDoc ({ docId, groupId = undefined }) {
+    console.log(`ProseMeteor AuthorityManager: AuthorityManager opening doc ${docId}`);
+    // if we're already tracking this doc with an authority locally on this server, we're all set
     if (this.authorities[docId]) {
-      return docId;
+      console.log(`ProseMeteor AuthorityManager: doc ${docId} authority exists locally, returning local ip ${this.registry.fullUrlWithProtocol} `);
+      return this.registry.fullUrlWithProtocol;
     }
-    console.log(`ProseMeteor AuthorityManager: AuthorityManager opening doc ${docId}, creating new authority`);
+    const chooseProperAuthority = () => {
+      const authorityUrl = this.registry.getUrlOfAuthorityHostingDoc({ docId, groupId });
+      if (authorityUrl === this.registry.fullUrlWithProtocol) {
+        console.log(`ProseMeteor AuthorityManager: this was server chosen to host doc ${docId}`);
+        // if this server is the server hosting that doc, we can create a local authority
+        this.createAuthority({ docId, groupId });
+        return authorityUrl;
+      } else {
+        console.log(`ProseMeteor AuthorityManager: server chosen to host doc ${docId}: ${authorityUrl}`);
+        // authority will live on another server. run health check
+        const healthCheckPassed = this.registry.runSingleHealthCheck({ authorityUrl });
+        if (!healthCheckPassed) {
+          // bad server. try again
+          console.log(`ProseMeteor AuthorityManager: server ${authorityUrl} FAILED health check, selecting another`);
+          return chooseProperAuthority();
+        }
+        console.log(`ProseMeteor AuthorityManager: server ${authorityUrl} PASSED health check, instructing it to create a local authority`);
+        // instruct the correct server to create a local authority
+        let authorityServerConn;
+        try {
+          authorityServerConn = DDP.connect(authorityUrl);
+        } catch (e) {
+          console.log(`ProseMeteor AuthorityManager: ddp connection to chosen authority server failed: ${e}`);
+        }
+        authorityServerConn.call('ProseMeteor.createAuthority', { docId, groupId });
+        return authorityUrl;
+      }
+    };
+    const correctAuthorityUrl = chooseProperAuthority();
+    console.log(`ProseMeteor AuthorityManager: got correct authority url ${correctAuthorityUrl}`);
+    return correctAuthorityUrl;
+  }
+
+  /**
+  *  Creates a new Authority in memory to track the doc.
+  * @param {Object} params
+  * @param {String} params.docId         the unique id of the doc
+  * @param {String} [params.groupId]     an id to associate this doc with other docs
+  */
+  createAuthority ({ docId, groupId }) {
+    console.log(`ProseMeteor AuthorityManager: (ip ${this.registry.fullUrlWithProtocol}) creating authority for doc ${docId}`);
     // create a new authority
     this.authorities[docId] = new Authority({
       docId,
+      groupId,
       documentsColl: this.documentsColl,
       streamer: this.streamerServer,
       snapshotIntervalMs: this.snapshotIntervalMs

--- a/lib/imports/api/authority/server/authority-manager.js
+++ b/lib/imports/api/authority/server/authority-manager.js
@@ -34,7 +34,7 @@ export class AuthorityManager {
   }
 
   /**
-  * Createds Meteor Methods to allow clients to communicate with the AuthorityManager.
+  * Creates Meteor Methods to allow clients to communicate with the AuthorityManager.
   */
   setupClientMethods () {
     let self = this;

--- a/lib/imports/api/authority/server/authority-manager.js
+++ b/lib/imports/api/authority/server/authority-manager.js
@@ -32,9 +32,8 @@ export class AuthorityManager {
         console.error(`Failed to register Authority with AuthorityRegistry: ${err}`);
       }
       console.log(`ProseMeteor AuthorityManager: Full registry: ${JSON.stringify(this.registry.fullRegistry(), null, 2)}`);
+      this.setupClientMethods();
     });
-
-    this.setupClientMethods();
   }
 
   /**

--- a/lib/imports/api/authority/server/authority-manager.js
+++ b/lib/imports/api/authority/server/authority-manager.js
@@ -106,7 +106,21 @@ export class AuthorityManager {
       console.log(`ProseMeteor AuthorityManager: doc ${docId} authority exists locally, returning local ip ${this.registry.fullUrl} `);
       return this.registry.fullUrl;
     }
-    // get array of eligible authorities
+
+    // if another authority already has this doc, use it
+    const existingAuthorityOfDocId = this.registry.getAuthorityInfoByDocId({ docId });
+    if (existingAuthorityOfDocId) {
+      console.log(`ProseMeteor AuthorityManager: Found an authority hosting docId "${docId}", selecting it "${existingAuthorityOfDocId.fullUrl}"`);
+      return existingAuthorityOfDocId.fullUrl;
+    }
+
+    // if another authority already has this doc's groupId, use it
+    const existingAuthorityOfGroupId = this.registry.getAuthorityInfoByGroupId({ groupId });
+    if (existingAuthorityOfGroupId) {
+      console.log(`ProseMeteor AuthorityManager: Found an authority hosting the groupId ${groupId} for docId "${docId}", selecting it "${existingAuthorityOfGroupId.fullUrl}"`);
+      return existingAuthorityOfGroupId.fullUrl;
+    }
+    // get array of eligible authorities. if an authority is already hosting the doc, it will be returned as the only element in the array
     const eligibleAuthorities = this.registry.getEligibleAuthoritiesToHostDoc({ docId, groupId });
     let finalAuthority;
 

--- a/lib/imports/api/authority/server/authority-manager.js
+++ b/lib/imports/api/authority/server/authority-manager.js
@@ -25,7 +25,7 @@ export class AuthorityManager {
     this.streamerServer = streamer;
     this.snapshotIntervalMs = snapshotIntervalMs;
     this.ip = ip.address();
-    this.port = process.env.PORT;
+    this.port = parseInt(process.env.PORT);
     this.registry = new AuthorityRegistry();
     this.registry.register({ ip: this.ip, port: this.port }, (err) => {
       if (err) {

--- a/lib/imports/api/authority/server/authority-manager.js
+++ b/lib/imports/api/authority/server/authority-manager.js
@@ -31,7 +31,7 @@ export class AuthorityManager {
       if (err) {
         console.error(`Failed to register Authority with AuthorityRegistry: ${err}`);
       }
-      console.log(`Full registry: ${JSON.stringify(this.registry.fullRegistry(), null, 2)}`);
+      console.log(`ProseMeteor AuthorityManager: Full registry: ${JSON.stringify(this.registry.fullRegistry(), null, 2)}`);
     });
 
     this.setupClientMethods();
@@ -91,7 +91,7 @@ export class AuthorityManager {
     if (this.authorities[docId]) {
       return docId;
     }
-    console.log(`AuthorityManager opening doc ${docId}, creating new authority`);
+    console.log(`ProseMeteor AuthorityManager: AuthorityManager opening doc ${docId}, creating new authority`);
     // create a new authority
     this.authorities[docId] = new Authority({
       docId,

--- a/lib/imports/api/authority/server/authority-manager.js
+++ b/lib/imports/api/authority/server/authority-manager.js
@@ -2,6 +2,8 @@ import { Authority } from './authority';
 import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
 import { check } from 'meteor/check';
+import ip from 'ip';
+import { AuthorityRegistry } from './../../authority-registry/server/authority-registry';
 
 export class AuthorityManager {
   /**
@@ -22,6 +24,14 @@ export class AuthorityManager {
     this.authorities = {};
     this.streamerServer = streamer;
     this.snapshotIntervalMs = snapshotIntervalMs;
+    this.ip = ip.address();
+    this.port = process.env.PORT;
+    this.registry = new AuthorityRegistry();
+    this.registry.register({ ip: this.ip, port: this.port }, (err) => {
+      if (err) {
+        throw new Meteor.Error(500, 'Failed to register Authority with AuthorityRegistry');
+      }
+    });
 
     this.setupClientMethods();
   }

--- a/lib/imports/api/authority/server/authority-manager.js
+++ b/lib/imports/api/authority/server/authority-manager.js
@@ -27,10 +27,11 @@ export class AuthorityManager {
     this.ip = ip.address();
     this.port = parseInt(process.env.PORT);
     this.registry = new AuthorityRegistry();
-    this.registry.register({ ip: this.ip, port: this.port }, (err) => {
+    this.registry.register({ ip: this.ip, port: this.port }, (err, res) => {
       if (err) {
         console.error(`Failed to register Authority with AuthorityRegistry: ${err}`);
       }
+      console.log(`Full registry: ${JSON.stringify(this.registry.fullRegistry(), null, 2)}`);
     });
 
     this.setupClientMethods();

--- a/lib/imports/api/authority/server/authority-manager.js
+++ b/lib/imports/api/authority/server/authority-manager.js
@@ -117,8 +117,19 @@ export class AuthorityManager {
     // if another authority already has this doc's groupId, use it
     const existingAuthorityOfGroupId = this.registry.getAuthorityInfoByGroupId({ groupId });
     if (existingAuthorityOfGroupId) {
-      console.log(`ProseMeteor AuthorityManager: Found an authority hosting the groupId ${groupId} for docId "${docId}", selecting it "${existingAuthorityOfGroupId.fullUrl}"`);
-      return existingAuthorityOfGroupId.fullUrl;
+      if (existingAuthorityOfGroupId.fullUrl === this.registry.fullUrl) {
+        console.log(`ProseMeteor AuthorityManager: this app server is already hosting groupId ${groupId} of doc ${docId}, creating local Authority`);
+        // if this server is the server hosting that doc, we can create a local authority
+        this.createAuthority({ docId, groupId });
+        return existingAuthorityOfGroupId.fullUrl;
+      }
+      // if the remote server is healthy, tell it to create an authority
+      const healthCheckPassed = this.registry.runSingleHealthCheck({ authorityUrl: existingAuthorityOfGroupId.fullUrl });
+      if (healthCheckPassed) {
+        console.log(`ProseMeteor AuthorityManager: a server is already hosting groupId ${groupId} for doc ${docId}`);
+        this.instructServerToCreateAuthority({ fullUrl: existingAuthorityOfGroupId.fullUrl, docId, groupId });
+        return existingAuthorityOfGroupId.fullUrl;
+      }
     }
     // get array of eligible authorities. if an authority is already hosting the doc, it will be returned as the only element in the array
     const eligibleAuthorities = this.registry.getEligibleAuthoritiesToHostDoc({ docId, groupId });
@@ -128,7 +139,7 @@ export class AuthorityManager {
     for (let i = 0; i < eligibleAuthorities.length; i++) {
       const authority = eligibleAuthorities[i];
       if (authority.fullUrl === this.registry.fullUrl) {
-        console.log(`ProseMeteor AuthorityManager: this was server chosen to host doc ${docId}`);
+        console.log(`ProseMeteor AuthorityManager: this app server was chosen to host doc ${docId}`);
         // if this server is the server hosting that doc, we can create a local authority
         this.createAuthority({ docId, groupId });
         finalAuthority = authority;
@@ -181,6 +192,24 @@ export class AuthorityManager {
     });
     this.registry.addDocToAuthority({ docId, groupId });
     return;
+  }
+
+  /**
+  *  Creates a new Authority in memory to track the doc.
+  * @param {Object} params
+  * @param {String} params.fullUrl       full url of app the server to instruct
+  * @param {String} params.docId         the unique id of the doc
+  * @param {String} [params.groupId]     an id to associate this doc with other docs
+  */
+  instructServerToCreateAuthority ({ fullUrl, docId, groupId = null }) {
+    // instruct the correct server to create a local authority
+    let authorityServerConn;
+    try {
+      authorityServerConn = DDP.connect(fullUrl);
+      authorityServerConn.call('ProseMeteor.createAuthority', { docId, groupId });
+    } catch (e) {
+      console.log(`ProseMeteor AuthorityManager: ddp connection to chosen authority server failed: ${e}`);
+    }
   }
 
   /**

--- a/lib/imports/api/authority/server/authority-manager.js
+++ b/lib/imports/api/authority/server/authority-manager.js
@@ -2,7 +2,6 @@ import { Authority } from './authority';
 import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
 import { check } from 'meteor/check';
-import ip from 'ip';
 import { AuthorityRegistry } from './../../authority-registry/server/authority-registry';
 
 export class AuthorityManager {
@@ -24,10 +23,8 @@ export class AuthorityManager {
     this.authorities = {};
     this.streamerServer = streamer;
     this.snapshotIntervalMs = snapshotIntervalMs;
-    this.ip = ip.address();
-    this.port = parseInt(process.env.PORT);
     this.registry = new AuthorityRegistry();
-    this.registry.register({ ip: this.ip, port: this.port }, (err, res) => {
+    this.registry.register((err, res) => {
       if (err) {
         console.error(`Failed to register Authority with AuthorityRegistry: ${err}`);
       }

--- a/lib/imports/api/authority/server/authority-manager.js
+++ b/lib/imports/api/authority/server/authority-manager.js
@@ -81,7 +81,7 @@ export class AuthorityManager {
   openDoc ({ docId }) {
     check(docId, String);
     if (!docId) {
-      throw new Meteor.Error(`no-authority-exists`, `This AuthorityManager doesn't have an Authority tracking a document with docId ${docId}.`);
+      throw new Meteor.Error('no-authority-exists', `This AuthorityManager doesn't have an Authority tracking a document with docId ${docId}.`);
     }
     // if we're already tracking this doc with an authority, we're all set
     if (this.authorities[docId]) {
@@ -105,7 +105,7 @@ export class AuthorityManager {
   latestDocState ({ docId }) {
     check(docId, String);
     if (!this.authorities[docId]) {
-      throw new Meteor.Error(`no-authority-exists`, `This AuthorityManager doesn't have an Authority tracking a document with docId ${docId}.`);
+      throw new Meteor.Error('no-authority-exists', `This AuthorityManager doesn't have an Authority tracking a document with docId ${docId}.`);
     }
     return this.authorities[docId].latestDocState();
   }
@@ -120,7 +120,7 @@ export class AuthorityManager {
     check(version, Number);
     check(docId, String);
     if (!this.authorities[docId]) {
-      throw new Meteor.Error(`no-authority-exists`, `This AuthorityManager doesn't have an Authority tracking a document with docId ${docId}.`);
+      throw new Meteor.Error('no-authority-exists', `This AuthorityManager doesn't have an Authority tracking a document with docId ${docId}.`);
     }
     return this.authorities[docId].stepsSince({ version });
   }
@@ -139,7 +139,7 @@ export class AuthorityManager {
     check(stepsJSON, Array);
     check(clientId, Number);
     if (!this.authorities[docId]) {
-      throw new Meteor.Error(`no-authority-exists`, `This AuthorityManager doesn't have an Authority tracking a document with docId ${docId}.`);
+      throw new Meteor.Error('no-authority-exists', `This AuthorityManager doesn't have an Authority tracking a document with docId ${docId}.`);
     }
     this.authorities[docId].receiveSteps({ clientId, version, stepsJSON });
     //     this.authorities[docId].receiveSteps.bind(this.authorities[docId], { clientId, version, stepsJSON });

--- a/lib/imports/api/authority/server/authority-manager.js
+++ b/lib/imports/api/authority/server/authority-manager.js
@@ -76,14 +76,13 @@ export class AuthorityManager {
       },
 
       // open a doc, setting up its authority
-      'ProseMeteor.openDoc' ({ docId, groupId = undefined }) {
+      'ProseMeteor.openDoc' ({ docId }) {
         check(docId, String);
-        check(groupId, Match.Maybe(String));
-        return self.openDoc({ docId, groupId });
+        return self.openDoc({ docId });
       },
 
       // creates an authority in memory
-      'ProseMeteor.createAuthority' ({ docId, groupId = undefined }) {
+      'ProseMeteor.createAuthority' ({ docId, groupId = null }) {
         check(docId, String);
         check(groupId, Match.Maybe(String));
         self.createAuthority({ docId, groupId });
@@ -95,46 +94,59 @@ export class AuthorityManager {
   * Open a ProseMirror document. Instructs appropriate server to create a server in memory and returns the server's URL.
   * @param {Object} params
   * @param {String} params.docId         the unique id of the doc
-  * @param {String} [params.groupId]     an id to associate this doc with other docs
+  * @returns {String}  authorityUrl      url of the chosen authority
   */
-  openDoc ({ docId, groupId = undefined }) {
+  openDoc ({ docId }) {
     console.log(`ProseMeteor AuthorityManager: AuthorityManager opening doc ${docId}`);
+    // get this doc's groupId if it has one
+    const thisDoc = this.documentsColl.findOne({ docId });
+    const groupId = thisDoc.groupId || undefined;
     // if we're already tracking this doc with an authority locally on this server, we're all set
     if (this.authorities[docId]) {
-      console.log(`ProseMeteor AuthorityManager: doc ${docId} authority exists locally, returning local ip ${this.registry.fullUrlWithProtocol} `);
-      return this.registry.fullUrlWithProtocol;
+      console.log(`ProseMeteor AuthorityManager: doc ${docId} authority exists locally, returning local ip ${this.registry.fullUrl} `);
+      return this.registry.fullUrl;
     }
-    const chooseProperAuthority = () => {
-      const authorityUrl = this.registry.getUrlOfAuthorityHostingDoc({ docId, groupId });
-      if (authorityUrl === this.registry.fullUrlWithProtocol) {
+    // get array of eligible authorities
+    const eligibleAuthorities = this.registry.getEligibleAuthoritiesToHostDoc({ docId, groupId });
+    let finalAuthority;
+
+    // find the first eligible authority that is healthy and instruct it to create a doc
+    for (let i = 0; i < eligibleAuthorities.length; i++) {
+      const authority = eligibleAuthorities[i];
+      if (authority.fullUrl === this.registry.fullUrl) {
         console.log(`ProseMeteor AuthorityManager: this was server chosen to host doc ${docId}`);
         // if this server is the server hosting that doc, we can create a local authority
         this.createAuthority({ docId, groupId });
-        return authorityUrl;
+        finalAuthority = authority;
+        break;
       } else {
-        console.log(`ProseMeteor AuthorityManager: server chosen to host doc ${docId}: ${authorityUrl}`);
+        console.log(`ProseMeteor AuthorityManager: server chosen to host doc ${docId}: ${authority.fullUrl} (${authority._id})`);
         // authority will live on another server. run health check
-        const healthCheckPassed = this.registry.runSingleHealthCheck({ authorityUrl });
+        const healthCheckPassed = this.registry.runSingleHealthCheck({ authorityUrl: authority.fullUrl });
         if (!healthCheckPassed) {
           // bad server. try again
-          console.log(`ProseMeteor AuthorityManager: server ${authorityUrl} FAILED health check, selecting another`);
-          return chooseProperAuthority();
+          console.log(`ProseMeteor AuthorityManager: server ${authority.fullUrl} FAILED health check, selecting another`);
+          continue;
         }
-        console.log(`ProseMeteor AuthorityManager: server ${authorityUrl} PASSED health check, instructing it to create a local authority`);
+        console.log(`ProseMeteor AuthorityManager: server ${authority.fullUrl} PASSED health check, instructing it to create a local authority`);
         // instruct the correct server to create a local authority
         let authorityServerConn;
         try {
-          authorityServerConn = DDP.connect(authorityUrl);
+          authorityServerConn = DDP.connect(authority.fullUrl);
         } catch (e) {
-          console.log(`ProseMeteor AuthorityManager: ddp connection to chosen authority server failed: ${e}`);
+          console.log(`ProseMeteor AuthorityManager: ddp connection to chosen authority server failed, selecting another: ${e}`);
+          continue;
         }
         authorityServerConn.call('ProseMeteor.createAuthority', { docId, groupId });
-        return authorityUrl;
+        finalAuthority = authority;
+        break;
       }
-    };
-    const correctAuthorityUrl = chooseProperAuthority();
-    console.log(`ProseMeteor AuthorityManager: got correct authority url ${correctAuthorityUrl}`);
-    return correctAuthorityUrl;
+    }
+    if (!finalAuthority) {
+      throw new Meteor.Error('failed-select-authority', `Failed to select an appropriate authority server for doc ${docId}`);
+    }
+    console.log(`ProseMeteor AuthorityManager: got correct authority url ${finalAuthority.fullUrl}`);
+    return finalAuthority.fullUrl;
   }
 
   /**
@@ -143,8 +155,8 @@ export class AuthorityManager {
   * @param {String} params.docId         the unique id of the doc
   * @param {String} [params.groupId]     an id to associate this doc with other docs
   */
-  createAuthority ({ docId, groupId }) {
-    console.log(`ProseMeteor AuthorityManager: (ip ${this.registry.fullUrlWithProtocol}) creating authority for doc ${docId}`);
+  createAuthority ({ docId, groupId = null }) {
+    console.log(`ProseMeteor AuthorityManager: (ip ${this.registry.fullUrl}) creating authority for doc ${docId}`);
     // create a new authority
     this.authorities[docId] = new Authority({
       docId,
@@ -153,6 +165,7 @@ export class AuthorityManager {
       streamer: this.streamerServer,
       snapshotIntervalMs: this.snapshotIntervalMs
     });
+    this.registry.addDocToAuthority({ docId, groupId });
     return;
   }
 

--- a/lib/imports/api/authority/server/authority-manager.js
+++ b/lib/imports/api/authority/server/authority-manager.js
@@ -13,17 +13,14 @@ export class AuthorityManager {
   * @param {Object} params
   * @param {Collection} params.collection       a Collection instance that is used to store ProseMirror docs
   * @param {Streamer}  params.streamer          a Streamer object that contains .emit() and .on() methods for streaming events with clients
-  * @param {Number} params.snapshotIntervalMs   interval in millseconds that Authority will store a snapshot of an open doc to db
   * @constructor
   */
-  constructor ({ documentsColl, streamer, snapshotIntervalMs }) {
+  constructor ({ documentsColl, streamer }) {
     check(documentsColl, Mongo.Collection);
     check(streamer, Meteor.Streamer);
-    check(snapshotIntervalMs, Number);
     this.documentsColl = documentsColl;
     this.authorities = {};
     this.streamerServer = streamer;
-    this.snapshotIntervalMs = snapshotIntervalMs;
     this.registry = new AuthorityRegistry();
 
     // bind class methods
@@ -187,10 +184,9 @@ export class AuthorityManager {
       docId,
       groupId,
       documentsColl: this.documentsColl,
-      streamer: this.streamerServer,
-      snapshotIntervalMs: this.snapshotIntervalMs
+      streamer: this.streamerServer
     });
-    this.registry.addDocToAuthority({ docId, groupId });
+    this.registry.addDocToAuthorityServer({ docId, groupId });
     return;
   }
 

--- a/lib/imports/api/authority/server/authority.js
+++ b/lib/imports/api/authority/server/authority.js
@@ -5,25 +5,28 @@ import { CollabStep } from './collab-step';
 import { CollabStepClientId } from './collab-step-client-id';
 import { defaultSchema } from './../../../prosemirror/dist/model/defaultschema';
 import { storeDocSnapshot, getLatestDocSnapshot } from './../../documents/both/methods';
-import { check } from 'meteor/check';
+import { check, Match } from 'meteor/check';
 
 export class Authority {
   /**
    * Central authority to track a ProseMirror document, apply steps from clients, and notify clients when changes occur.
    * @param {Object} params
    * @param {String} params.docId                     the id of the doc this Authority tracks
+   * @param {String} [params.groupId]                 an id to associate this doc with other docs
    * @param {Collection} params.documentsColl       a Meteor Collection that is used to store ProseMirror docs
    * @param {Streamer}  params.streamer               a Streamer object that contains .emit() and .on() methods for streaming events with clients
    * @param {Number} params.snapshotIntervalMs       interval in millseconds that Authority will store a snapshot of an open doc to db
    * @constructor
    */
-  constructor ({ docId, documentsColl, streamer, snapshotIntervalMs }) {
+  constructor ({ docId, groupId = undefined, documentsColl, streamer, snapshotIntervalMs }) {
     check(docId, String);
+    check(groupId, Match.Maybe(String));
     check(documentsColl, Mongo.Collection);
     check(streamer, Meteor.Streamer);
     check(snapshotIntervalMs, Number);
     console.log(`Authority created for doc id: ${docId}`);
     this.docId = docId;
+    this.groupId = groupId;
     this.documentsColl = documentsColl;
     this.streamerServer = streamer;
     this.snapshotIntervalMs = snapshotIntervalMs;

--- a/lib/imports/api/authority/server/authority.js
+++ b/lib/imports/api/authority/server/authority.js
@@ -36,7 +36,7 @@ export class Authority {
         throw new Meteor.Error(500, 'Authority error getting latest snapshot for doc ' + this.docId + ':' + err);
       }
       let { docJSON } = res;
-      console.log('Authority got latest snapshot for doc ' + this.docId + ':', JSON.stringify(res, null, 2));
+      console.log('Authority got latest snapshot for doc ' + this.docId);
 
       this.doc = defaultSchema.nodeFromJSON(docJSON);
       this.steps = [];

--- a/lib/imports/api/authority/server/authority.js
+++ b/lib/imports/api/authority/server/authority.js
@@ -92,8 +92,8 @@ export class Authority {
       this.stepClientIds.push(new CollabStepClientId({ versionAppliedTo: currentDocVersion, clientId }));
     });
     // notify listening clients that new steps have arrived
-    console.log(`Authority notifying clients of new steps`);
-    this.streamerServer.emit(`authorityNewSteps`);
+    console.log('Authority notifying clients of new steps');
+    this.streamerServer.emit('authorityNewSteps');
   }
 
   /**

--- a/lib/imports/api/authority/server/authority.js
+++ b/lib/imports/api/authority/server/authority.js
@@ -6,6 +6,7 @@ import { CollabStepClientId } from './collab-step-client-id';
 import { defaultSchema } from './../../../prosemirror/dist/model/defaultschema';
 import { storeDocSnapshot, getLatestDocSnapshot } from './../../documents/both/methods';
 import { check, Match } from 'meteor/check';
+import { proseMeteorConfig } from './../../config/server/prosemeteor-config';
 
 export class Authority {
   /**
@@ -15,21 +16,18 @@ export class Authority {
    * @param {String} [params.groupId]                 an id to associate this doc with other docs
    * @param {Collection} params.documentsColl       a Meteor Collection that is used to store ProseMirror docs
    * @param {Streamer}  params.streamer               a Streamer object that contains .emit() and .on() methods for streaming events with clients
-   * @param {Number} params.snapshotIntervalMs       interval in millseconds that Authority will store a snapshot of an open doc to db
    * @constructor
    */
-  constructor ({ docId, groupId = null, documentsColl, streamer, snapshotIntervalMs }) {
+  constructor ({ docId, groupId = null, documentsColl, streamer }) {
     check(docId, String);
     check(groupId, Match.Maybe(String));
     check(documentsColl, Mongo.Collection);
     check(streamer, Meteor.Streamer);
-    check(snapshotIntervalMs, Number);
     console.log(`Authority created for doc id: ${docId}`);
     this.docId = docId;
     this.groupId = groupId;
     this.documentsColl = documentsColl;
     this.streamerServer = streamer;
-    this.snapshotIntervalMs = snapshotIntervalMs;
     this.numberOfSnapshots = this.documentsColl.find({ docId: this.docId }).count();
 
     try {
@@ -138,7 +136,7 @@ export class Authority {
         console.log(`Authority storing snapshot for doc ${this.docId}, version ${version}`);
         this.storeSnapshot();
       }
-    }, this.snapshotIntervalMs);
+    }, proseMeteorConfig.snapshotIntervalMs);
   }
 
   /**

--- a/lib/imports/api/authority/server/authority.js
+++ b/lib/imports/api/authority/server/authority.js
@@ -18,7 +18,7 @@ export class Authority {
    * @param {Number} params.snapshotIntervalMs       interval in millseconds that Authority will store a snapshot of an open doc to db
    * @constructor
    */
-  constructor ({ docId, groupId = undefined, documentsColl, streamer, snapshotIntervalMs }) {
+  constructor ({ docId, groupId = null, documentsColl, streamer, snapshotIntervalMs }) {
     check(docId, String);
     check(groupId, Match.Maybe(String));
     check(documentsColl, Mongo.Collection);
@@ -32,13 +32,11 @@ export class Authority {
     this.snapshotIntervalMs = snapshotIntervalMs;
     this.numberOfSnapshots = this.documentsColl.find({ docId: this.docId }).count();
 
-    getLatestDocSnapshot.call({
-      docId: this.docId
-    }, (err, res) => {
-      if (err) {
-        console.log(`Authority error getting latest snapshot for doc ${this.docId}: ${err}`);
-      }
-      let { docJSON } = res;
+    try {
+      const latestSnapshot = getLatestDocSnapshot.call({
+        docId: this.docId
+      });
+      let { docJSON } = latestSnapshot;
       console.log(`Authority got latest snapshot for doc ${this.docId}`);
 
       this.doc = defaultSchema.nodeFromJSON(docJSON);
@@ -46,11 +44,13 @@ export class Authority {
       this.stepClientIds = [];
 
       // store info about last snapshot so we only store on interval, and only when changes have occurred
-      this.latestSnapshot = res;
+      this.latestSnapshot = latestSnapshot;
 
       // start interval to store doc snapshots
       this.startSnapshotInterval();
-    });
+    } catch (e) {
+      console.log(`Authority error getting latest snapshot for doc ${this.docId}: ${e}`);
+    }
   }
 
   /**

--- a/lib/imports/api/collab-editor/client/collab-editor.js
+++ b/lib/imports/api/collab-editor/client/collab-editor.js
@@ -1,5 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { ProseMirror } from './../../../prosemirror/dist/edit';
+import { DDP } from 'meteor/ddp-client';
 import './../../../prosemirror/dist/inputrules/autoinput';
 import './../../../prosemirror/dist/menu/tooltipmenu';
 import './../../../prosemirror/dist/menu/menubar';
@@ -11,10 +12,19 @@ import { Step } from './../../../prosemirror/dist/transform';
 const streamerClient = new Meteor.Streamer('prosemirror-pipe');
 
 export default class CollabEditor {
-  constructor ({ docId, proseMirrorOptions }) {
+  constructor ({ docId, groupId = undefined, proseMirrorOptions }) {
     this.docId = docId;
+    this.groupId = groupId;
     this.proseMirrorOptions = proseMirrorOptions;
     this.streamerClient = streamerClient;
+    this.ddpConnection = undefined;
+
+    // bind class methods
+    this.setupEditor = this.setupEditor.bind(this);
+    this.createEditor = this.createEditor.bind(this);
+    this.sendStepsToAuthority = this.sendStepsToAuthority.bind(this);
+    this.receieveNewStepsFromAuthority = this.receieveNewStepsFromAuthority.bind(this);
+
     this.setupEditor();
   }
 
@@ -26,21 +36,25 @@ export default class CollabEditor {
 
     // tell the AuthorityManager to open the doc
     Meteor.call('ProseMeteor.openDoc', {
-      docId: self.docId
-    }, function (err) {
+      docId: self.docId,
+      groupId: self.groupId
+    }, (err, authorityUrl) => {
       if (err) {
         console.error('CollabEditor authority openDoc error:', err);
         // TODO: handle error
       }
+      console.log(`${this.docId}: CollabEditor opened doc and creating ddp connection to authority url ${authorityUrl}`);
+      self.ddpConnection = DDP.connect(authorityUrl);
+      console.log(`${this.docId}: CollabEditor created ddp connection successfully`);
       // the authority is ready. get the latest doc state
-      Meteor.call('ProseMeteor.latestDocState', {
+      self.ddpConnection.call('ProseMeteor.latestDocState', {
         docId: self.docId
-      }, function (err, latestDocState) {
+      }, (err, latestDocState) => {
         if (err) {
-          console.error('CollabEditor get latestDocState error:', err);
+          console.error(`${this.docId} CollabEditor get latestDocState error: ${err}`);
           // TODO: handle error
         }
-        console.log('CollabEditor got latestDocState:', latestDocState);
+        console.log(`${this.docId}: CollabEditor got latestDocState: ${JSON.stringify(latestDocState, null, 2)}`);
 
         // create an editor with the latest state
         self.createEditor(latestDocState);
@@ -55,7 +69,7 @@ export default class CollabEditor {
   * @param {Object} params.docJSON     the doc's state represented as JS object
   */
   createEditor ({ version, docJSON }) {
-    console.log(`Creating collab editor with doc version: ${version}`);
+    console.log(`${this.docId}: Creating collab editor with doc version: ${version}`);
     this.editor = new ProseMirror({
       ...this.proseMirrorOptions,
       collab: {
@@ -66,24 +80,22 @@ export default class CollabEditor {
     this.collab = this.editor.mod.collab;
 
     // respond to collab send event by sending local steps to authority
-    this.collab.on('mustSend', this.sendStepsToAuthority.bind(this));
+    this.collab.on('mustSend', this.sendStepsToAuthority);
 
     // when authortiy tells us there's new steps, receieve them
-    this.streamerClient.on('authorityNewSteps', this.receieveNewStepsFromAuthority.bind(this));
+    this.streamerClient.on('authorityNewSteps', this.receieveNewStepsFromAuthority);
   }
 
   sendStepsToAuthority () {
     const data = this.collab.sendableSteps();
-    console.log('CollabEditor sendStepsToAuthority(), data=', data);
+    console.log(`${this.docId}: CollabEditor sendStepsToAuthority(), data=${JSON.stringify(data, null, 2)}`);
     // convert to JSON so we can send it over the wire
     const stepsJSON = data.steps.map((step) => {
       return step.toJSON();
     });
 
-    let self = this;
-
-    Meteor.call('ProseMeteor.clientSubmitSteps', {
-      docId: self.docId,
+    this.ddpConnection.call('ProseMeteor.clientSubmitSteps', {
+      docId: this.docId,
       version: data.version,
       stepsJSON,
       clientId: data.clientID   // renaming ID to Id to follow Meteor paradigm (i.e. Meteor.userId())
@@ -93,16 +105,16 @@ export default class CollabEditor {
   receieveNewStepsFromAuthority () {
     let self = this;
     // get the steps since local version from authority
-    Meteor.call('ProseMeteor.stepsSince', {
+    this.ddpConnection.call('ProseMeteor.stepsSince', {
       docId: self.docId,
       version: self.collab.version
     }, function (err, newData) {
       if (err) {
-        console.error(`CollabEditor get steps from Authority since v${self.collab.version}, error: ${err}`);
+        console.error(`${this.docId} CollabEditor get steps from Authority since v${self.collab.version}, error: ${err}`);
         // TODO: handle error
       }
       let parsedNewData = JSON.parse(newData);
-      console.log(`CollabEditor got steps from Authority since v${self.collab.version}`);
+      console.log(`${this.docId}: CollabEditor got steps from Authority since v${self.collab.version}`);
 
       let { steps, clientIds } = parsedNewData;
       // convert steps to Step instances
@@ -118,17 +130,4 @@ export default class CollabEditor {
       }
     });
   }
-  //   Meteor.call('ProseMeteor.latestDocState', {
-  //     docId: this.docId
-  //   }, function (err, latestDocState) {
-  //     if (err) {
-  //       console.error('CollabEditor get latestDocState error:', err);
-  //       // TODO: handle error
-  //     }
-  //     console.log('CollabEditor got latestDocState:', latestDocState);
-  //
-  //     // create an editor with the latest state
-  //     self.createEditor(latestDocState)
-  //   });
-  // }
 }

--- a/lib/imports/api/collab-editor/client/collab-editor.js
+++ b/lib/imports/api/collab-editor/client/collab-editor.js
@@ -8,7 +8,7 @@ import { defaultSchema } from './../../../prosemirror/dist/model/defaultschema';
 import { Step } from './../../../prosemirror/dist/transform';
 
 // share a global streamerClient across all CollabEditors
-const streamerClient = new Meteor.Streamer(`prosemirror-pipe`);
+const streamerClient = new Meteor.Streamer('prosemirror-pipe');
 
 export default class CollabEditor {
   constructor ({ docId, proseMirrorOptions }) {
@@ -25,22 +25,22 @@ export default class CollabEditor {
     let self = this;
 
     // tell the AuthorityManager to open the doc
-    Meteor.call(`ProseMeteor.openDoc`, {
+    Meteor.call('ProseMeteor.openDoc', {
       docId: self.docId
     }, function (err) {
       if (err) {
-        console.error(`CollabEditor authority openDoc error:`, err);
+        console.error('CollabEditor authority openDoc error:', err);
         // TODO: handle error
       }
       // the authority is ready. get the latest doc state
-      Meteor.call(`ProseMeteor.latestDocState`, {
+      Meteor.call('ProseMeteor.latestDocState', {
         docId: self.docId
       }, function (err, latestDocState) {
         if (err) {
-          console.error(`CollabEditor get latestDocState error:`, err);
+          console.error('CollabEditor get latestDocState error:', err);
           // TODO: handle error
         }
-        console.log(`CollabEditor got latestDocState:`, latestDocState);
+        console.log('CollabEditor got latestDocState:', latestDocState);
 
         // create an editor with the latest state
         self.createEditor(latestDocState);
@@ -66,15 +66,15 @@ export default class CollabEditor {
     this.collab = this.editor.mod.collab;
 
     // respond to collab send event by sending local steps to authority
-    this.collab.on(`mustSend`, this.sendStepsToAuthority.bind(this));
+    this.collab.on('mustSend', this.sendStepsToAuthority.bind(this));
 
     // when authortiy tells us there's new steps, receieve them
-    this.streamerClient.on(`authorityNewSteps`, this.receieveNewStepsFromAuthority.bind(this));
+    this.streamerClient.on('authorityNewSteps', this.receieveNewStepsFromAuthority.bind(this));
   }
 
   sendStepsToAuthority () {
     const data = this.collab.sendableSteps();
-    console.log(`CollabEditor sendStepsToAuthority(), data=`, data);
+    console.log('CollabEditor sendStepsToAuthority(), data=', data);
     // convert to JSON so we can send it over the wire
     const stepsJSON = data.steps.map((step) => {
       return step.toJSON();
@@ -82,7 +82,7 @@ export default class CollabEditor {
 
     let self = this;
 
-    Meteor.call(`ProseMeteor.clientSubmitSteps`, {
+    Meteor.call('ProseMeteor.clientSubmitSteps', {
       docId: self.docId,
       version: data.version,
       stepsJSON,
@@ -93,7 +93,7 @@ export default class CollabEditor {
   receieveNewStepsFromAuthority () {
     let self = this;
     // get the steps since local version from authority
-    Meteor.call(`ProseMeteor.stepsSince`, {
+    Meteor.call('ProseMeteor.stepsSince', {
       docId: self.docId,
       version: self.collab.version
     }, function (err, newData) {

--- a/lib/imports/api/collab-editor/client/collab-editor.js
+++ b/lib/imports/api/collab-editor/client/collab-editor.js
@@ -1,22 +1,23 @@
 import { Meteor } from 'meteor/meteor';
 import { ProseMirror } from './../../../prosemirror/dist/edit';
-import { DDP } from 'meteor/ddp-client';
 import './../../../prosemirror/dist/inputrules/autoinput';
 import './../../../prosemirror/dist/menu/tooltipmenu';
 import './../../../prosemirror/dist/menu/menubar';
 import './../../../prosemirror/dist/collab';
 import { defaultSchema } from './../../../prosemirror/dist/model/defaultschema';
 import { Step } from './../../../prosemirror/dist/transform';
+import { StreamerManager } from './streamer-manager';
 
-// share a global streamerClient across all CollabEditors
-const streamerClient = new Meteor.Streamer('prosemirror-pipe');
+// share streamerManager across all class instances
+const streamerManager = new StreamerManager('prosemirror-pipe');
 
 export default class CollabEditor {
   constructor ({ docId, groupId = undefined, proseMirrorOptions }) {
     this.docId = docId;
     this.groupId = groupId;
     this.proseMirrorOptions = proseMirrorOptions;
-    this.streamerClient = streamerClient;
+    this.streamerManager = streamerManager;
+    this.streamerClient = undefined;
     this.ddpConnection = undefined;
 
     // bind class methods
@@ -44,7 +45,9 @@ export default class CollabEditor {
         // TODO: handle error
       }
       console.log(`${this.docId}: CollabEditor opened doc and creating ddp connection to authority url ${authorityUrl}`);
-      self.ddpConnection = DDP.connect(authorityUrl);
+      const streamer = this.streamerManager.get(authorityUrl);
+      self.ddpConnection = streamer.ddpConnection;
+      self.streamerClient = streamer.streamerClient;
       console.log(`${this.docId}: CollabEditor created ddp connection successfully`);
       // the authority is ready. get the latest doc state
       self.ddpConnection.call('ProseMeteor.latestDocState', {

--- a/lib/imports/api/collab-editor/client/collab-editor.js
+++ b/lib/imports/api/collab-editor/client/collab-editor.js
@@ -113,11 +113,11 @@ export default class CollabEditor {
       version: self.collab.version
     }, function (err, newData) {
       if (err) {
-        console.error(`${this.docId} CollabEditor get steps from Authority since v${self.collab.version}, error: ${err}`);
+        console.error(`${self.docId} CollabEditor get steps from Authority since v${self.collab.version}, error: ${err}`);
         // TODO: handle error
       }
       let parsedNewData = JSON.parse(newData);
-      console.log(`${this.docId}: CollabEditor got steps from Authority since v${self.collab.version}`);
+      console.log(`${self.docId}: CollabEditor got steps from Authority since v${self.collab.version}`);
 
       let { steps, clientIds } = parsedNewData;
       // convert steps to Step instances

--- a/lib/imports/api/collab-editor/client/collab-editor.js
+++ b/lib/imports/api/collab-editor/client/collab-editor.js
@@ -12,7 +12,7 @@ import { StreamerManager } from './streamer-manager';
 const streamerManager = new StreamerManager('prosemirror-pipe');
 
 export default class CollabEditor {
-  constructor ({ docId, groupId = undefined, proseMirrorOptions }) {
+  constructor ({ docId, groupId = null, proseMirrorOptions }) {
     this.docId = docId;
     this.groupId = groupId;
     this.proseMirrorOptions = proseMirrorOptions;
@@ -48,7 +48,7 @@ export default class CollabEditor {
       const streamer = this.streamerManager.get(authorityUrl);
       self.ddpConnection = streamer.ddpConnection;
       self.streamerClient = streamer.streamerClient;
-      console.log(`${this.docId}: CollabEditor created ddp connection successfully`);
+      console.log(`${this.docId}: CollabEditor stored ddp connection successfully`);
       // the authority is ready. get the latest doc state
       self.ddpConnection.call('ProseMeteor.latestDocState', {
         docId: self.docId

--- a/lib/imports/api/collab-editor/client/streamer-manager.js
+++ b/lib/imports/api/collab-editor/client/streamer-manager.js
@@ -1,0 +1,50 @@
+import { Meteor } from 'meteor/meteor';
+import { DDP } from 'meteor/ddp-client';
+
+/**
+* Manages multiple Meteor streamer instances using the same name across any number of urls.
+*/
+export class StreamerManager {
+  /**
+  * Create a StreamerManager.
+  * @param {String} name      name of the streamer
+  */
+  constructor (name) {
+    this.streamers = {};
+    this.name = name;
+
+    this.get = this.get.bind(this);
+  }
+
+  /**
+  * Get the streamer instance for the provided url. Creates a new instance if one doesn't exist.
+  * @param {String} url
+  */
+  get (url) {
+    // if a streamer exists for this url, return it
+    if (this.streamers[url] instanceof StreamerInstance) {
+      return this.streamers[url];
+    }
+    // no streamer exists for this url, create one and return it
+    this.streamers[url] = new StreamerInstance({
+      name: this.name,
+      url
+    });
+    return this.streamers[url];
+  }
+};
+
+/**
+*   Represents a single streamer object.
+*/
+class StreamerInstance {
+  constructor ({ name, url }) {
+    this.name = name;
+    this.url = url;
+
+    this.ddpConnection = DDP.connect(url);
+    this.streamerClient = new Meteor.Streamer(this.name, {
+      ddpConnection: this.ddpConnection
+    });
+  }
+}

--- a/lib/imports/api/config/server/prosemeteor-config.js
+++ b/lib/imports/api/config/server/prosemeteor-config.js
@@ -1,0 +1,62 @@
+/**
+* Configuration class for getting and setting config values for ProseMeteor.
+*/
+class ProseMeteorConfig {
+  constructor () {
+    // all possible config values
+    this._ip = undefined;
+    this._port = undefined;
+    this._protocol = undefined;
+    this._snapshotIntervalMs = undefined;
+    this._failedHealthChecksThreshold = undefined;
+  }
+  checkExists (key, value) {
+    if (typeof value === 'undefined' || value === null) {
+      throw new Error(`ProseMeteor ProseMeteorconfig: Nonexistant value "${value}" provided for ${key}`);
+    }
+  }
+  get ip () {
+    return this._ip;
+  }
+  set ip (value) {
+    this.checkExists('ip', value);
+    this._ip = value;
+  }
+  get port () {
+    return this._port;
+  }
+  set port (value) {
+    this.checkExists('port', value);
+    this._port = value;
+  }
+  get protocol () {
+    return this._protocol;
+  }
+  set protocol (value) {
+    this.checkExists('protocol', value);
+    if (['http', 'https'].indexOf(value) === -1) {
+      throw new Error(`ProseMeteor ProseMeteorConfig: protocol must be either "http" or "https", "${value}" provided`);
+    }
+    this._protocol = value;
+  }
+  get snapshotIntervalMs () {
+    return this._snapshotIntervalMs;
+  }
+  set snapshotIntervalMs (value) {
+    this.checkExists('snapshotIntervalMs', value);
+    this._snapshotIntervalMs = value;
+  }
+
+  get failedHealthChecksThreshold () {
+    return this._failedHealthChecksThreshold;
+  }
+  set failedHealthChecksThreshold (value) {
+    if (value < 3) {
+      console.warn('ProseMeteorConfig: Warning, setting failedHealthChecksThreshold to less than 3 might be dangerous since it can lead to servers being removed from the registry of available servers.');
+    }
+    this._failedHealthChecksThreshold = value;
+  }
+
+}
+
+export const proseMeteorConfig = new ProseMeteorConfig();

--- a/lib/imports/api/documents/both/collection.js
+++ b/lib/imports/api/documents/both/collection.js
@@ -1,7 +1,7 @@
 import { Mongo } from 'meteor/mongo';
 
 // todo: the collection name and field names should probably be configurable
-export const documentsColl = new Mongo.Collection('Documents');
+export const documentsColl = new Mongo.Collection('prosemeteor-documents');
 
 // Deny all client-side updates since we will be using methods to manage this collection
 documentsColl.deny({

--- a/lib/imports/api/documents/both/collection.js
+++ b/lib/imports/api/documents/both/collection.js
@@ -1,7 +1,7 @@
 import { Mongo } from 'meteor/mongo';
 
 // todo: the collection name and field names should probably be configurable
-export const documentsColl = new Mongo.Collection(`prosemeteor-documents`);
+export const documentsColl = new Mongo.Collection('prosemeteor-documents');
 
 // Deny all client-side updates since we will be using methods to manage this collection
 documentsColl.deny({

--- a/lib/imports/api/documents/both/methods.js
+++ b/lib/imports/api/documents/both/methods.js
@@ -55,8 +55,7 @@ export const createEmptyDoc = new ValidatedMethod({
       _id,
       ...documentSnapshot
     };
-    console.log('Inserted the following doc into the Documents collection:');
-    console.log(JSON.stringify(snapshotWithId, null, 2));
+    console.log('Inserted an empty doc into the prosemeteor-documents collection');
     return snapshotWithId;
   }
 });

--- a/lib/imports/api/documents/both/methods.js
+++ b/lib/imports/api/documents/both/methods.js
@@ -29,23 +29,26 @@ export const createEmptyDoc = new ValidatedMethod({
   validate (args) {
     check(args, {
       // can provide docId as string, or leave empty
-      docId: Match.Optional(String),
+      docId: Match.Maybe(String),
       // can provide text content, or leave emtpy to use default
-      textConcent: Match.Optional(String)
+      textContent: Match.Maybe(String),
+      groupId: Match.Maybe(String)
     });
   },
-  run (args) {
+  run ({
+    docId = Random.id(),    // generate random docId of none provided
+    groupId = null,
+    textContent = 'You can edit this text!'
+  }) {
     // create an empty doc with version 0
     let fixtureDoc = schema.node('doc', null, [schema.node('paragraph', null, [
-      schema.text(args.textConcent || 'You can edit this text!')
+      schema.text(textContent)
     ])]);
     let fixtureDocJSON = fixtureDoc.toJSON();
 
-    // if a docId was provided, use it. othwerise generate a random docId
-    let docId = args.docId || Random.id();
-
     let documentSnapshot = {
       docId,
+      groupId,
       docJSON: fixtureDocJSON,
       version: 0,
       timestamp: Date.now()

--- a/lib/imports/api/documents/both/methods.js
+++ b/lib/imports/api/documents/both/methods.js
@@ -5,7 +5,7 @@ import { Random } from 'meteor/random';
 import { ValidatedMethod } from 'meteor/mdg:validated-method';
 
 export const storeDocSnapshot = new ValidatedMethod({
-  name: `documents.storeDocSnapshot`,
+  name: 'documents.storeDocSnapshot',
   validate (args) {
     check(args, {
       docId: String,
@@ -25,7 +25,7 @@ export const storeDocSnapshot = new ValidatedMethod({
 });
 
 export const createEmptyDoc = new ValidatedMethod({
-  name: `documents.createEmptyDoc`,
+  name: 'documents.createEmptyDoc',
   validate (args) {
     check(args, {
       // can provide docId as string, or leave empty
@@ -36,8 +36,8 @@ export const createEmptyDoc = new ValidatedMethod({
   },
   run (args) {
     // create an empty doc with version 0
-    let fixtureDoc = schema.node(`doc`, null, [schema.node(`paragraph`, null, [
-      schema.text(args.textConcent || `You can edit this text!`)
+    let fixtureDoc = schema.node('doc', null, [schema.node('paragraph', null, [
+      schema.text(args.textConcent || 'You can edit this text!')
     ])]);
     let fixtureDocJSON = fixtureDoc.toJSON();
 
@@ -56,13 +56,13 @@ export const createEmptyDoc = new ValidatedMethod({
       _id,
       ...documentSnapshot
     };
-    console.log(`Inserted an empty doc into the prosemeteor-documents collection`);
+    console.log('Inserted an empty doc into the prosemeteor-documents collection');
     return snapshotWithId;
   }
 });
 
 export const getLatestDocSnapshot = new ValidatedMethod({
-  name: `documents.getLatestDocSnapshot`,
+  name: 'documents.getLatestDocSnapshot',
   validate (args) {
     check(args, {
       docId: String

--- a/lib/imports/api/prosemeteor/server/prosemeteor-server.js
+++ b/lib/imports/api/prosemeteor/server/prosemeteor-server.js
@@ -17,9 +17,9 @@ export class ProseMeteorServer {
     // store documents collection
     this.documentsColl = documentsColl;
     // create streamer for event communication with client
-    this.streamerServer = new Meteor.Streamer(`prosemirror-pipe`, { retransmit: false });
-    this.streamerServer.allowRead(`all`);
-    this.streamerServer.allowWrite(`all`);
+    this.streamerServer = new Meteor.Streamer('prosemirror-pipe', { retransmit: false });
+    this.streamerServer.allowRead('all');
+    this.streamerServer.allowWrite('all');
 
     // create authority manager  to create, delete authorities and communicate with clients
     this.authorityManager = new AuthorityManager({

--- a/lib/imports/api/prosemeteor/server/prosemeteor-server.js
+++ b/lib/imports/api/prosemeteor/server/prosemeteor-server.js
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import { AuthorityManager } from './../../authority/server/authority-manager';
 import { documentsColl } from './../../documents/both/collection';
-
+import { proseMeteorConfig } from './../../config/server/prosemeteor-config';
 /**
 * Main ProseMeteor server class that instantiates all of ProseMeteor on the server.
 */
@@ -9,11 +9,21 @@ export class ProseMeteorServer {
   /*
   * Main ProseMeteor class on the server.
   * @param {Object} params
-  * @param {Collection} params.documentsColl     Collection PM docs are stored in
+  * @param {String} params.protocol              protocol this server uses ('http' or 'https')
   * @param {Number} [params.snapshotIntervalMs]  interval in milliseconds that documents are backed up to a snapshot in db
   * @constructor
   */
-  constructor ({ snapshotIntervalMs = 5000 }) {
+  constructor ({
+    // set default config values if not provided.
+    protocol = 'http',                  // protocol this application's servers are communicating on
+    snapshotIntervalMs = 5000,          // how often documents are backed up in a snapshot when open
+    healthCheckIntervalMs = 1000 * 30,  // how often health checks are run against all other available application servers
+    failedHealthChecksThreshold = 5     // number of failed consecutive health checks that leads to a server being
+                                        // removed from the registry of servers available to host Authorities
+   }) {
+    if (!protocol) {
+      throw new Error('ProseMeteorServer: Protocol must be specified of either "http" or "https"');
+    }
     // store documents collection
     this.documentsColl = documentsColl;
     // create streamer for event communication with client
@@ -21,11 +31,16 @@ export class ProseMeteorServer {
     this.streamerServer.allowRead('all');
     this.streamerServer.allowWrite('all');
 
+    // set all config values
+    proseMeteorConfig.protocol = protocol;
+    proseMeteorConfig.snapshotIntervalMs = snapshotIntervalMs;
+    proseMeteorConfig.healthCheckIntervalMs = healthCheckIntervalMs;
+    proseMeteorConfig.failedHealthChecksThreshold = failedHealthChecksThreshold;
+
     // create authority manager  to create, delete authorities and communicate with clients
     this.authorityManager = new AuthorityManager({
       documentsColl,
-      streamer: this.streamerServer,
-      snapshotIntervalMs
+      streamer: this.streamerServer
     });
   }
 }

--- a/lib/imports/api/prosemeteor/server/prosemeteor-server.js
+++ b/lib/imports/api/prosemeteor/server/prosemeteor-server.js
@@ -21,9 +21,6 @@ export class ProseMeteorServer {
     failedHealthChecksThreshold = 5     // number of failed consecutive health checks that leads to a server being
                                         // removed from the registry of servers available to host Authorities
    }) {
-    if (!protocol) {
-      throw new Error('ProseMeteorServer: Protocol must be specified of either "http" or "https"');
-    }
     // store documents collection
     this.documentsColl = documentsColl;
     // create streamer for event communication with client

--- a/lib/imports/startup/client/client-index.js
+++ b/lib/imports/startup/client/client-index.js
@@ -1,4 +1,4 @@
 // Meteor.startup(() => {
 //   // code to run on server at startup
 // });import './prosemirrorAPI.js';
-console.log(`prosemeteor client startup`);
+console.log('prosemeteor client startup');

--- a/lib/imports/startup/server/fixtures/document-fixture.js
+++ b/lib/imports/startup/server/fixtures/document-fixture.js
@@ -9,7 +9,8 @@ Meteor.startup(() => {
     // create two empty docs for the PoC, to show that AuthorityManager can handle multiple Authorities. hardcode ids for now
     createEmptyDoc.call({
       docId: 'proofOfConceptDocId1',
-      textConcent: 'Demo 1, you can edit this text!'
+      textContent: 'Demo 1, you can edit this text!',
+      groupId: 'demoGroupId'
     }, (err, res) => {
       if (err) {
         console.error('Error while inserting empty doc:', err);
@@ -18,7 +19,8 @@ Meteor.startup(() => {
 
     createEmptyDoc.call({
       docId: 'proofOfConceptDocId2',
-      textConcent: 'Demo 2, you can edit this text!'
+      textContent: 'Demo 2, you can edit this text!',
+      groupId: 'demoGroupId'
     }, (err, res) => {
       if (err) {
         console.error('Error while inserting empty doc:', err);

--- a/lib/imports/startup/server/fixtures/document-fixture.js
+++ b/lib/imports/startup/server/fixtures/document-fixture.js
@@ -8,20 +8,20 @@ Meteor.startup(() => {
   if (documentsColl.find().count() === 0) {
     // create two empty docs for the PoC, to show that AuthorityManager can handle multiple Authorities. hardcode ids for now
     createEmptyDoc.call({
-      docId: `proofOfConceptDocId1`,
-      textConcent: `Demo 1, you can edit this text!`
+      docId: 'proofOfConceptDocId1',
+      textConcent: 'Demo 1, you can edit this text!'
     }, (err, res) => {
       if (err) {
-        console.error(`Error while inserting empty doc:`, err);
+        console.error('Error while inserting empty doc:', err);
       }
     });
 
     createEmptyDoc.call({
-      docId: `proofOfConceptDocId2`,
-      textConcent: `Demo 2, you can edit this text!`
+      docId: 'proofOfConceptDocId2',
+      textConcent: 'Demo 2, you can edit this text!'
     }, (err, res) => {
       if (err) {
-        console.error(`Error while inserting empty doc:`, err);
+        console.error('Error while inserting empty doc:', err);
       }
     });
   }

--- a/lib/tests/prosemirror-tests.js
+++ b/lib/tests/prosemirror-tests.js
@@ -6,8 +6,8 @@ import { name as packageName } from 'meteor/prosemirror';
 
 // Write your tests here!
 // Here is an example.
-Tinytest.add(`prosemirror - example`, function (test) {
-  test.equal(packageName, `prosemirror`);
+Tinytest.add('prosemirror - example', function (test) {
+  test.equal(packageName, 'prosemirror');
 });
 
 // test for Prosepipe setup

--- a/package.js
+++ b/package.js
@@ -15,6 +15,7 @@ Npm.depends({
   //  using local version in imports/prosemirror for now because the latest publish was a month ago and collab module API has changed since then,
   // we want the latest changes
   // prosemirror: '0.6.1'
+  ip: '1.1.3'
 });
 
 Package.onUse(function(api) {

--- a/package.js
+++ b/package.js
@@ -23,6 +23,7 @@ Package.onUse(function(api) {
   api.use('ecmascript');
   api.use('rocketchat:streamer@0.3.5');
   api.use('mdg:validated-method@1.1.0');
+  api.use('http');
   api.mainModule('lib/client/client-main.js', 'client');
   api.mainModule('lib/server/server-main.js', 'server');
 });

--- a/reset_demo
+++ b/reset_demo
@@ -1,0 +1,5 @@
+#!/bin/sh
+echo "---------------------------------"
+echo "Resetting the demo Meteor application"
+echo "---------------------------------"
+cd ./demo &&  meteor reset

--- a/run_demo
+++ b/run_demo
@@ -9,6 +9,7 @@ echo "---------------------------------"
 echo "Starting code linting in watch mode"
 echo "---------------------------------"
 
+trap 'jobs -p | xargs kill' exists  # kill the background process when parent is killed
 npm run lint:watch &
 
 echo "---------------------------------"


### PR DESCRIPTION
Alright this is a big change. ProseMeteor now automatically scales across any number of application servers.
- Now when a client creates a new editor instance, and calls the Meteor Method `ProseMeteor.openDoc`, it will be given the full URL of the server hosting the doc. All subsequent client communcation for that doc is done via a new DDP connection to that particular server
- each entry in the authority registry db collection maintains a list of all docIds and groupIds currently being hosted on that authority server (these are never cleared out at the moment, that will be addressed in [Issue 18](https://github.com/prosemeteor/prosemirror/issues/18))
- `authority-manager.js` `openDoc()`  will now choose the right authority to host the doc (or choose the authority already hosting either the docId or the doc's groupId). It defaults to preferring the server hosting the least number of documents currently
- Health checks are run against servers before they are chosen to make sure they're up (since we can't be sure they will be). Health checks are also run on a set interval (30 seconds currently), and if any server fails too many consecutively (5 currently) it's assumed to be down and removed from the registry. If it fails 4 but then passes the next one, it's failed count is reset to 0 and it's assumed to be up and healthy.
- Added a `reset-demo` shell script similar to `run-demo` for development and testing purposes

If you pull down this branch and run it, it should all just work as it was previously, but you can watch the logs to see it running all of the logic to select authority servers and run health checks against them.

for #8 and #20 

@funkyeah @ellery44 @archonic 
